### PR TITLE
ci: syntax error for flake8 version number

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ coverage = {extras = ["toml"], version = "^6.4"}
 safety = "^2.1.1"
 mypy = "^0.971"
 xdoctest = {extras = ["colors"], version = "^1.0.2"}
-flake8-bandit = "^~4.1.1"
+flake8-bandit = "~4.1.1"
 flake8-bugbear = ">=21.9.2"
 flake8-docstrings = "^1.6.0"
 flake8-rst-docstrings = "^0.2.7"


### PR DESCRIPTION
The `^~4.1.1 ` has `~` and `^`, that's a syntax error. CI is failing to build due to it.