### PR TITLE
fix:  undo bump of virtualenv, back to 20.21.0

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,4 +1,4 @@
 pip==23.1.2
 poetry==1.4.2
-virtualenv==20.23.0
+virtualenv==20.21.0
 poetry-dynamic-versioning==0.21.4


### PR DESCRIPTION
Reverts Autodesk/pgbelt#217

Apparently broke the release action. https://github.com/Autodesk/pgbelt/actions/runs/4864843131