### PR TITLE
test: ability to build and install pgbelt CLI locally for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-40s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install whatever you have locally
-	poetry install --no-dev
+	pip3 install -e .
 
 setup: ## Install development requirements. You should be in a virtualenv
 	poetry install && pre-commit install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ pylint = "^2.17.2"
 pytest-asyncio = "~0.21.0"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.0.0", "setuptools"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
The previous `make install` command would not produce the `belt` CLI tool for local testing. This PR fixes that, so you are able to make local changes and actually run `belt` to test them.