### PR TITLE
test: muuuuch easier local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,9 @@ test: ## Run tests
 	docker build . -t autodesk/pgbelt:latest && docker build tests/integration/files/postgres13-pglogical-docker/ -t autodesk/postgres-pglogical-docker:13 && docker-compose run tests
 
 tests: test
+
+local-dev: ## Sets up docker containers for Postgres DBs and gets you into a docker container with pgbelt installed. DC: integrationtest-datacenter, DB: integrationtestdb
+	docker build . -t autodesk/pgbelt:latest && docker build tests/integration/files/postgres13-pglogical-docker/ -t autodesk/postgres-pglogical-docker:13 && docker-compose run localtest
+
+clean-docker: ## Stop and remove all docker containers and images made from local testing
+	docker stop $$(docker ps -aq --filter name=^/pgbelt) && docker rm $$(docker ps -aq --filter name=^/pgbelt) && docker-compose down --rmi all

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-40s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install whatever you have locally
-	poetry install --no-dev
+	pip3 install -e .
 
 setup: ## Install development requirements. You should be in a virtualenv
 	poetry install && pre-commit install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,30 @@ services:
     networks:
       - datacenter
 
+  localtest:
+    image: autodesk/pgbelt:latest
+    environment:
+      TEST_PG_SRC_HOST: localhost
+      TEST_PG_SRC_IP: 10.5.0.5
+      TEST_PG_SRC_DB: src
+      TEST_PG_SRC_PORT: 5432
+      TEST_PG_SRC_ROOT_USERNAME: postgres
+      TEST_PG_SRC_ROOT_PASSWORD: postgres
+      TEST_PG_DST_HOST: localhost
+      TEST_PG_DST_IP: 10.5.0.6
+      TEST_PG_DST_DB: dst
+      TEST_PG_DST_PORT: 5432
+      TEST_PG_DST_ROOT_USERNAME: postgres
+      TEST_PG_DST_ROOT_PASSWORD: postgres
+    command: bash -c "poetry run python3 tests/integration/conftest.py && pip3 install -e . && bash"
+    depends_on:
+      db-src:
+        condition: service_healthy
+      db-dst:
+        condition: service_healthy
+    networks:
+      - datacenter
+
 networks:
   datacenter:
     driver: bridge

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ pylint = "^2.17.2"
 pytest-asyncio = "~0.21.0"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.0.0", "setuptools"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
With this new code, we can simply run `make local-dev` to get the following:

1. Two Postgres DBs get spun up as Docker containers, one loaded with test data,
2. One container as a shell running a local version of `belt`

This way, if you need to test new features or commands, you can quickly test them against databases.

This builds and leaves around some docker containers. To clean up, run `make clean-docker`.