### PR TITLE
fix: remote.py error handling needs to shore up plugin error

### DIFF
--- a/pgbelt/config/remote.py
+++ b/pgbelt/config/remote.py
@@ -153,7 +153,7 @@ async def resolve_remote_config(
             f"Config resolver class {classname} from {module} does not implement resolve"
         )
         return None
-    except RemoteConfigError e:
+    except RemoteConfigError as e:
         logger.error(f"Failed to resolve remote configuration for {db} {dc}. RemoteConfigError {e}")
         return None
     except ValidationError:

--- a/pgbelt/config/remote.py
+++ b/pgbelt/config/remote.py
@@ -153,8 +153,8 @@ async def resolve_remote_config(
             f"Config resolver class {classname} from {module} does not implement resolve"
         )
         return None
-    except RemoteConfigError:
-        logger.error(f"Failed to resolve remote configuration for {db} {dc}")
+    except RemoteConfigError e:
+        logger.error(f"Failed to resolve remote configuration for {db} {dc}. RemoteConfigError {e}")
         return None
     except ValidationError:
         logger.error(


### PR DESCRIPTION
This helps us know from the remote config plugin what error the plugin itself saw when it throw an error.