### PR TITLE
fix: stop using default replication set

### DIFF
--- a/pgbelt/util/pglogical.py
+++ b/pgbelt/util/pglogical.py
@@ -105,7 +105,7 @@ async def configure_replication_set(
         except Exception as e:
             logger.debug(f"Could not create replication set 'pgbelt': {e}")
 
-    logger.info(f"Configuring default replication set with tables: {tables}")
+    logger.info(f"Configuring 'pgbelt' replication set with tables: {tables}")
     for table in tables:
         async with pool.acquire() as conn:
             async with conn.transaction():
@@ -113,9 +113,9 @@ async def configure_replication_set(
                     await conn.execute(
                         f"SELECT pglogical.replication_set_add_table('pgbelt', '\"{table}\"');"
                     )
-                    logger.debug(f"{table} added to default replication set")
+                    logger.debug(f"Table '{table}' added to 'pgbelt' replication set")
                 except UniqueViolationError:
-                    logger.debug(f"{table} already in default replication set")
+                    logger.debug(f"Table '{table}' already in 'pgbelt' replication set")
 
 
 async def configure_node(pool: Pool, name: str, dsn: str, logger: Logger) -> None:
@@ -153,6 +153,7 @@ async def configure_subscription(
                 await conn.execute(
                     f"""SELECT pglogical.create_subscription(
                         subscription_name:='{name}',
+                        replication_sets:='{{pgbelt}}',
                         provider_dsn:='{provider_dsn}',
                         synchronize_structure:=false,
                         synchronize_data:={'true' if name.startswith('pg1') else 'false'},

--- a/pgbelt/util/pglogical.py
+++ b/pgbelt/util/pglogical.py
@@ -97,16 +97,14 @@ async def configure_replication_set(
     """
     Add each table in the given list to the default replication set
     """
-    logger.info(f"Creating new replication set 'pgbelt'")
+    logger.info("Creating new replication set 'pgbelt'")
     async with pool.acquire() as conn:
         try:
-            await conn.execute(
-                "SELECT pglogical.create_replication_set('pgbelt');"
-            )
-            logger.debug(f"{table} added to default replication set")
+            await conn.execute("SELECT pglogical.create_replication_set('pgbelt');")
+            logger.debug("Created the 'pgbelt' replication set")
         except Exception as e:
             logger.debug(f"Could not create replication set 'pgbelt': {e}")
-    
+
     logger.info(f"Configuring default replication set with tables: {tables}")
     for table in tables:
         async with pool.acquire() as conn:

--- a/pgbelt/util/pglogical.py
+++ b/pgbelt/util/pglogical.py
@@ -103,7 +103,7 @@ async def configure_replication_set(
             "SELECT pglogical.create_replication_set('pgbelt');"
         )
         logger.debug(f"{table} added to default replication set")
-    except Exception e:
+    except Exception as e:
         logger.debug(f"Could not create replication set 'pgbelt': {e}")
     
     logger.info(f"Configuring default replication set with tables: {tables}")

--- a/pgbelt/util/pglogical.py
+++ b/pgbelt/util/pglogical.py
@@ -97,14 +97,14 @@ async def configure_replication_set(
     """
     Add each table in the given list to the default replication set
     """
-    logger.info(f"Creating new replication set pg1_pg2")
+    logger.info(f"Creating new replication set 'pgbelt'")
     try:
         await conn.execute(
             "SELECT pglogical.create_replication_set('pgbelt');"
         )
         logger.debug(f"{table} added to default replication set")
     except Exception e:
-        logger.debug(f"Could not create replication set pg1_pg2: {e}")
+        logger.debug(f"Could not create replication set 'pgbelt': {e}")
     
     logger.info(f"Configuring default replication set with tables: {tables}")
     for table in tables:

--- a/pgbelt/util/pglogical.py
+++ b/pgbelt/util/pglogical.py
@@ -98,13 +98,14 @@ async def configure_replication_set(
     Add each table in the given list to the default replication set
     """
     logger.info(f"Creating new replication set 'pgbelt'")
-    try:
-        await conn.execute(
-            "SELECT pglogical.create_replication_set('pgbelt');"
-        )
-        logger.debug(f"{table} added to default replication set")
-    except Exception as e:
-        logger.debug(f"Could not create replication set 'pgbelt': {e}")
+    async with pool.acquire() as conn:
+        try:
+            await conn.execute(
+                "SELECT pglogical.create_replication_set('pgbelt');"
+            )
+            logger.debug(f"{table} added to default replication set")
+        except Exception as e:
+            logger.debug(f"Could not create replication set 'pgbelt': {e}")
     
     logger.info(f"Configuring default replication set with tables: {tables}")
     for table in tables:

--- a/pgbelt/util/pglogical.py
+++ b/pgbelt/util/pglogical.py
@@ -206,8 +206,8 @@ async def teardown_replication_set(pool: Pool, logger: Logger) -> None:
     async with pool.acquire() as conn:
         async with conn.transaction():
             try:
-                await conn.execute("SELECT pglogical.drop_replication_set('default');")
-                logger.debug("Replication set 'default' dropped")
+                await conn.execute("SELECT pglogical.drop_replication_set('pgbelt');")
+                logger.debug("Replication set 'pgbelt' dropped")
             except (
                 InvalidSchemaNameError,
                 UndefinedFunctionError,

--- a/pgbelt/util/pglogical.py
+++ b/pgbelt/util/pglogical.py
@@ -97,13 +97,22 @@ async def configure_replication_set(
     """
     Add each table in the given list to the default replication set
     """
+    logger.info(f"Creating new replication set pg1_pg2")
+    try:
+        await conn.execute(
+            "SELECT pglogical.create_replication_set('pgbelt');"
+        )
+        logger.debug(f"{table} added to default replication set")
+    except Exception e:
+        logger.debug(f"Could not create replication set pg1_pg2: {e}")
+    
     logger.info(f"Configuring default replication set with tables: {tables}")
     for table in tables:
         async with pool.acquire() as conn:
             async with conn.transaction():
                 try:
                     await conn.execute(
-                        f"SELECT pglogical.replication_set_add_table('default', '\"{table}\"');"
+                        f"SELECT pglogical.replication_set_add_table('pgbelt', '\"{table}\"');"
                     )
                     logger.debug(f"{table} added to default replication set")
                 except UniqueViolationError:


### PR DESCRIPTION
Fixes #271 

Confirmed by running a whole cutover with our local dev environment `make local-dev`, then ran `belt teardown` at the end, then truncated the tables in the destination, then started replication again. Confirmed the `users` table was populated in the end!