### PR TITLE
test: local dev container uses local mount for faster testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ venv
 build/*
 dist/*
 logs/*
+configs/integrationtest-datacenter/*
 .python-version
 .mypy_cache
 __pycache__/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,8 @@ Simply run the following to spin the above up and drop yourself into your contai
 
 _Note_: the DC and DB for the above environment are [here](https://github.com/Autodesk/pgbelt/blob/main/tests/integration/conftest.py#L20-L21).
 
+Note: your local code will be _mounted_ to your container instead of copied. This allows you to edit your code on your laptop, then go into the container and run `pip3 install -e .` to update your container's `belt` binary for quick testing iterations.
+
 Once you are done, you can exit out of the above container. Then, for cleanliness, please run the following to clean up `docker` and `docker-compose`:
 
     make clean-docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
 FROM python:3.11-slim
-COPY ./ /opt/pgbelt
-WORKDIR /opt/pgbelt
 
 RUN set -e \
     && apt-get -y update \
@@ -9,5 +7,4 @@ RUN set -e \
 
 RUN set -e \
     && python -m pip install --upgrade pip \
-    && pip install poetry poetry-dynamic-versioning \
-    && poetry install
+    && pip install poetry poetry-dynamic-versioning

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM python:3.11-slim
+COPY ./ /opt/pgbelt
+WORKDIR /opt/pgbelt
 
 RUN set -e \
     && apt-get -y update \
@@ -7,4 +9,5 @@ RUN set -e \
 
 RUN set -e \
     && python -m pip install --upgrade pip \
-    && pip install poetry poetry-dynamic-versioning
+    && pip install poetry poetry-dynamic-versioning \
+    && poetry install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       TEST_PG_DST_PORT: 5432
       TEST_PG_DST_ROOT_USERNAME: postgres
       TEST_PG_DST_ROOT_PASSWORD: postgres
-    command: bash -c "poetry run python3 tests/integration/conftest.py && pip3 install -e . && bash"
+    command: bash -c "cd /pgbelt-volume/ && poetry install && poetry run python3 tests/integration/conftest.py && pip3 install -e . && bash"
     depends_on:
       db-src:
         condition: service_healthy
@@ -90,6 +90,8 @@ services:
         condition: service_healthy
     networks:
       - datacenter
+    volumes:
+      - ./:/pgbelt-volume/:rw
 
 networks:
   datacenter:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       TEST_PG_DST_PORT: 5432
       TEST_PG_DST_ROOT_USERNAME: postgres
       TEST_PG_DST_ROOT_PASSWORD: postgres
-    command: bash -c "cd /pgbelt-volume/ && poetry install && poetry run python3 tests/integration/conftest.py && pip3 install -e . && bash"
+    command: bash -c "cd /pgbelt-volume/ && poetry run python3 tests/integration/conftest.py && pip3 install -e . && bash"
     depends_on:
       db-src:
         condition: service_healthy


### PR DESCRIPTION
@jdcallet brought this up as a good feature to have.

This change allows for usage of `make local-dev` to not require you to clean up your local environment to alter your code and build a new testable copy of `belt`.

You can now instead run `make local-dev` to spin up the SRC/DST DB containers, and your `belt` container instead builds `belt` based on the local code you have on your laptop as a volume. Therefore, when you make a code change, you can just run `pip install -e .` to update your test container's `belt` binary instead of rebuilding everything.

Note: it is indeed redundant to volume while the container is built with the build-time copy of the `pgbelt` code. I decided against removing that local copy in the Dockerfile to keep our CI steps from not needing to install `poetry` dependencies on each CI step (see the `black` and `flake8` steps - they are run using that built container).