### PR TITLE
test: update integration tests to check non-public schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ venv
 build/*
 dist/*
 logs/*
-configs/integrationtest-datacenter/*
+configs/testdc/*
 schemas/*
 .python-version
 .mypy_cache

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test: ## Run tests
 
 tests: test
 
-local-dev: ## Sets up docker containers for Postgres DBs and gets you into a docker container with pgbelt installed. DC: integrationtest-datacenter, DB: integrationtestdb
+local-dev: ## Sets up docker containers for Postgres DBs and gets you into a docker container with pgbelt installed. DC: testdc, DB: testdb
 	docker build . -t autodesk/pgbelt:latest && docker build tests/integration/files/postgres13-pglogical-docker/ -t autodesk/postgres-pglogical-docker:13 && docker-compose run localtest
 
 clean-docker: ## Stop and remove all docker containers and images made from local testing

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,5 @@
 from os import environ
+from sys import argv
 from shutil import rmtree
 
 import pytest
@@ -10,15 +11,23 @@ from pgbelt.config.models import DbupgradeConfig
 from pgbelt.config.models import User
 
 
-async def _create_dbupgradeconfig() -> DbupgradeConfig:
+async def _create_dbupgradeconfig(
+    non_public_schema: bool = False, exodus: bool = False
+) -> DbupgradeConfig:
     """
     Function for creating a DbupgradeConfig object for testing.
     We also save it to disk since the pgbelt commands will look for it there.
+
+    If you want to test with a non-public schema, set non_public_schema to True.
+    If you want to test the migration of a subset of tables, set exodus to True.
     """
 
     config = DbupgradeConfig(
-        db="integrationtestdb",
-        dc="integrationtest-datacenter",
+        db="testdb",
+        dc="testdc",
+        schema_name="non_public_schema" if non_public_schema else "public",
+        tables=["users2"] if exodus else [],
+        sequences=["users2_id_seq"] if exodus else [],
     )
 
     config.src = DbConfig(
@@ -57,7 +66,7 @@ async def _create_dbupgradeconfig() -> DbupgradeConfig:
     return config
 
 
-async def _prepare_databases(config: DbupgradeConfig):
+async def _prepare_databases(config: DbupgradeConfig, non_public_schema: bool = False):
     """
     Given the root URIs for the source and destination databases:
     1. Create the owner user on both databases
@@ -65,33 +74,67 @@ async def _prepare_databases(config: DbupgradeConfig):
     3. Load the test data into the source database
     """
 
-    # Get the root URIs
-    src_root_uri_with_root_db, dst_root_uri_with_root_db = _root_uris(config)
-
     # Load test data and schema SQL
     with open("tests/integration/files/test_schema_data.sql") as f:
         test_schema_data = f.read()
 
-    # Make the following in the src container: owner user, db
-    async with create_pool(src_root_uri_with_root_db, min_size=1) as pool:
-        async with pool.acquire() as conn:
-            await conn.execute(
-                f"CREATE ROLE {config.src.owner_user.name} LOGIN PASSWORD '{config.src.owner_user.pw}'",
-            )
-            await conn.execute("CREATE DATABASE src")
+    # Just replace all the `public.` with `non_public_schema.` if non_public_schema is True
+    if non_public_schema:
+        test_schema_data = test_schema_data.replace("public.", "non_public_schema.")
+
+    # Get the root connections to the root DBs
+    src_root_uri_with_root_db, dst_root_uri_with_root_db = _root_uris(config)
+    src_root_user_root_db_pool, dst_root_user_root_db_pool = await asyncio.gather(
+        create_pool(src_root_uri_with_root_db, min_size=1),
+        create_pool(dst_root_uri_with_root_db, min_size=1),
+    )
+
+    # Create the owner user
+    await asyncio.gather(
+        src_root_user_root_db_pool.execute(
+            f"CREATE ROLE {config.src.owner_user.name} LOGIN PASSWORD '{config.src.owner_user.pw}'",
+        ),
+        dst_root_user_root_db_pool.execute(
+            f"CREATE ROLE {config.dst.owner_user.name} LOGIN PASSWORD '{config.dst.owner_user.pw}'",
+        ),
+    )
+
+    # Create the databases
+    await asyncio.gather(
+        src_root_user_root_db_pool.execute(
+            f"CREATE DATABASE src WITH OWNER = {config.src.owner_user.name}"
+        ),
+        dst_root_user_root_db_pool.execute(
+            f"CREATE DATABASE dst WITH OWNER = {config.dst.owner_user.name}"
+        ),
+    )
+
+    src_owner_user_logical_db_pool, dst_owner_user_logical_db_pool = (
+        await asyncio.gather(
+            create_pool(config.src.owner_uri, min_size=1),
+            create_pool(config.dst.owner_uri, min_size=1),
+        )
+    )
+
+    # Create the non_public_schema if non_public_schema is True
+    if non_public_schema:
+        await asyncio.gather(
+            src_owner_user_logical_db_pool.execute(f"CREATE SCHEMA non_public_schema"),
+            dst_owner_user_logical_db_pool.execute(f"CREATE SCHEMA non_public_schema"),
+        )
+        await asyncio.gather(
+            src_owner_user_logical_db_pool.execute(
+                f"GRANT CREATE ON SCHEMA non_public_schema TO {config.src.owner_user.name}"
+            ),
+            dst_owner_user_logical_db_pool.execute(
+                f"GRANT CREATE ON SCHEMA non_public_schema TO {config.dst.owner_user.name}"
+            ),
+        )
 
     # With the db made, load data into src
-    async with create_pool(config.src.owner_uri, min_size=1) as pool:
-        async with pool.acquire() as conn:
-            await conn.execute(test_schema_data)
-
-    # Make the following in the dst container: owner user, db
-    async with create_pool(dst_root_uri_with_root_db, min_size=1) as pool:
-        async with pool.acquire() as conn:
-            await conn.execute(
-                f"CREATE ROLE {config.dst.owner_user.name} LOGIN PASSWORD '{config.dst.owner_user.pw}'",
-            )
-            await conn.execute("CREATE DATABASE dst")
+    await asyncio.gather(
+        src_owner_user_logical_db_pool.execute(test_schema_data),
+    )
 
 
 def _root_uris(config: DbupgradeConfig) -> tuple[str, str]:
@@ -150,7 +193,7 @@ async def _empty_out_database(config: DbupgradeConfig) -> None:
 
 @pytest.mark.asyncio
 @pytest_asyncio.fixture
-async def setup_db_upgrade_config():
+async def setup_db_upgrade_config_public_schema():
     """
     Fixture for preparing the test databases and creating a DbupgradeConfig object.
     This fixture will also clean up after the test (removing local files and tearing down against the DBs).
@@ -168,15 +211,98 @@ async def setup_db_upgrade_config():
     await _empty_out_database(test_db_upgrade_config)
 
     # Delete the config that was saved to disk by the setup
-    rmtree("configs/integrationtest-datacenter")
+    rmtree("configs/testdc")
+    rmtree("schemas/")
+
+
+@pytest.mark.asyncio
+@pytest_asyncio.fixture
+async def setup_db_upgrade_config_non_public_schema():
+    """
+    Same as above, but with a non-public schema.
+    """
+
+    # Create the config
+    test_db_upgrade_config = await _create_dbupgradeconfig(non_public_schema=True)
+
+    # Prepare the databases
+    await _prepare_databases(test_db_upgrade_config, non_public_schema=True)
+
+    yield test_db_upgrade_config
+
+    # Clear out all data and stuff in the database containers :shrug:
+    await _empty_out_database(test_db_upgrade_config)
+
+    # Delete the config that was saved to disk by the setup
+    rmtree("configs/testdc")
+    rmtree("schemas/")
+
+
+@pytest.mark.asyncio
+@pytest_asyncio.fixture
+async def setup_db_upgrade_config_public_schema_exodus():
+    """
+    Fixture for preparing the test databases and creating a DbupgradeConfig object.
+    This fixture will also clean up after the test (removing local files and tearing down against the DBs).
+    """
+
+    # Create the config
+    test_db_upgrade_config = await _create_dbupgradeconfig(exodus=True)
+
+    # Prepare the databases
+    await _prepare_databases(test_db_upgrade_config)
+
+    yield test_db_upgrade_config
+
+    # Clear out all data and stuff in the database containers :shrug:
+    await _empty_out_database(test_db_upgrade_config)
+
+    # Delete the config that was saved to disk by the setup
+    rmtree("configs/testdc")
+    rmtree("schemas/")
+
+
+@pytest.mark.asyncio
+@pytest_asyncio.fixture
+async def setup_db_upgrade_config_non_public_schema_exodus():
+    """
+    Same as the base fixture, but with a non-public schema and exodus-style (moving a subset of data).
+    """
+
+    # Create the config
+    test_db_upgrade_config = await _create_dbupgradeconfig(
+        non_public_schema=True, exodus=True
+    )
+
+    # Prepare the databases
+    await _prepare_databases(test_db_upgrade_config, non_public_schema=True)
+
+    yield test_db_upgrade_config
+
+    # Clear out all data and stuff in the database containers :shrug:
+    await _empty_out_database(test_db_upgrade_config)
+
+    # Delete the config that was saved to disk by the setup
+    rmtree("configs/testdc")
     rmtree("schemas/")
 
 
 # This is a hacky way of doing it, but I don't want to duplicate code.
 # If this code is called directly, we can use it to set up the databases and create the config for
 # local interactive testing.
+
+# This will create the datasets.
 if __name__ == "__main__":
-    config = asyncio.run(_create_dbupgradeconfig())
-    asyncio.run(_prepare_databases(config))
+
+    # Check if any flags were passed using argv
+    if "--non-public-schema" in argv:
+        print("Creating non-public schema dataset...")
+        non_public_schema = True
+    else:
+        print("Creating public schema dataset...")
+        non_public_schema = False
+
+    config = asyncio.run(_create_dbupgradeconfig(non_public_schema))
+    asyncio.run(_prepare_databases(config, non_public_schema))
 
     print("Local databases are ready for local testing!")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -9,32 +9,59 @@ import pgbelt
 import pytest
 
 
-@pytest.mark.asyncio
-async def test_main_workflow(setup_db_upgrade_config):
+async def _check_status(config, src_dst_status, dst_src_status):
+    # Sleep 1, repeat until target status is seen.
+    pgbelt.cmd.status.echo = Mock()
+    not_replicating = True
+    i = 4
+    while not_replicating and i > 0:
+        sleep(1)
+        await pgbelt.cmd.status.status(db=None, dc=config.dc)
+
+        status_echo_call_arg = pgbelt.cmd.status.echo.call_args[0][0]
+
+        # Regex for the two columns to be in the correct state
+        matches = re.findall(
+            rf"^\S+\s+\S+{src_dst_status}\S+\s+\S+{dst_src_status}.*",
+            status_echo_call_arg.split("\n")[2],
+        )
+        if len(matches) == 1:
+            not_replicating = False
+        elif i > 0:
+            i = i - 1
+        else:
+            raise AssertionError(
+                f"Timed out waiting for src->dst: {src_dst_status}, dst->src: {dst_src_status} state. Ended with: {status_echo_call_arg}"
+            )
+
+
+async def _test_check_connectivity(config):
     # Run check_connectivity and make sure all green, no red
-    pgbelt.cmd.convenience.echo = AsyncMock()
-    await pgbelt.cmd.convenience.check_connectivity(
-        db=setup_db_upgrade_config.db, dc=setup_db_upgrade_config.dc
-    )
+    pgbelt.cmd.convenience.echo = Mock()
+    await pgbelt.cmd.convenience.check_connectivity(db=config.db, dc=config.dc)
     check_connectivity_echo_call_arg = pgbelt.cmd.convenience.echo.call_args[0][0]
     assert "\x1b[31m" not in check_connectivity_echo_call_arg
 
+    await _check_status(config, "unconfigured", "unconfigured")
+
+
+async def _test_precheck(config):
     # Run precheck and make sure all green, no red
     pgbelt.cmd.preflight.echo = Mock()
-    await pgbelt.cmd.preflight.precheck(
-        db=setup_db_upgrade_config.db, dc=setup_db_upgrade_config.dc
-    )
+    await pgbelt.cmd.preflight.precheck(db=config.db, dc=config.dc)
     preflight_echo_call_arg = pgbelt.cmd.preflight.echo.call_args[0][0]
     assert "\x1b[31m" not in preflight_echo_call_arg
 
+    await _check_status(config, "unconfigured", "unconfigured")
+
+
+async def _test_setup(config):
     # Run Setup
-    await pgbelt.cmd.setup.setup(
-        db=setup_db_upgrade_config.db, dc=setup_db_upgrade_config.dc
-    )
+    await pgbelt.cmd.setup.setup(db=config.db, dc=config.dc)
 
     # Ensure Schema in the destination doesn't have NOT VALID, no Indexes
     p = subprocess.Popen(
-        ["pg_dump", "-s", setup_db_upgrade_config.dst.root_dsn],
+        ["pg_dump", "-s", config.dst.root_dsn],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -46,66 +73,23 @@ async def test_main_workflow(setup_db_upgrade_config):
         assert "NOT VALID" not in c
         assert "INDEX" not in c
 
-    # Sleep 1, repeat until 'replicating' forward
-    pgbelt.cmd.status.echo = Mock()
-    not_replicating = True
-    i = 4
-    while not_replicating and i > 0:
-        sleep(1)
-        await pgbelt.cmd.status.status(db=None, dc=setup_db_upgrade_config.dc)
+    await _check_status(config, "replicating", "unconfigured")
 
-        status_echo_call_arg = pgbelt.cmd.status.echo.call_args[0][0]
 
-        # Regex for 2nd column (src -> dest) saying replicating in green
-        matches = re.findall(
-            r"^\S+\s+\S+replicating\S+\s+\S+unconfigured.*",
-            status_echo_call_arg.split("\n")[2],
-        )
-        if len(matches) == 1:
-            not_replicating = False
-        elif i > 0:
-            i = i - 1
-        else:
-            raise AssertionError(
-                "Timed out waiting for src -> dest to get to the 'replicating' state."
-            )
-
+async def _test_setup_back_replication(config):
     # Set up back replication
-    await pgbelt.cmd.setup.setup_back_replication(
-        db=setup_db_upgrade_config.db, dc=setup_db_upgrade_config.dc
-    )
+    await pgbelt.cmd.setup.setup_back_replication(db=config.db, dc=config.dc)
 
-    # Sleep 1, repeat until 'replicating' backward
-    not_replicating = True
-    i = 4
-    while not_replicating and i > 0:
-        sleep(1)
-        await pgbelt.cmd.status.status(db=None, dc=setup_db_upgrade_config.dc)
+    await _check_status(config, "replicating", "replicating")
 
-        status_echo_call_arg = pgbelt.cmd.status.echo.call_args[0][0]
 
-        # Regex for 2nd column (src -> dest) saying replicating in green
-        matches = re.findall(
-            r"^\S+\s+\S+replicating\S+\s+\S+replicating.*",
-            status_echo_call_arg.split("\n")[2],
-        )
-        if len(matches) == 1:
-            not_replicating = False
-        elif i > 0:
-            i = i - 1
-        else:
-            raise AssertionError(
-                "Timed out waiting for src <- dest to get to the 'replicating' state."
-            )
-
+async def _test_create_indexes(config):
     # Load in Indexes
-    await pgbelt.cmd.schema.create_indexes(
-        db=setup_db_upgrade_config.db, dc=setup_db_upgrade_config.dc
-    )
+    await pgbelt.cmd.schema.create_indexes(db=config.db, dc=config.dc)
 
     # Ensure Schema in the destination has Indexes
     p = subprocess.Popen(
-        ["pg_dump", "-s", setup_db_upgrade_config.dst.root_dsn],
+        ["pg_dump", "-s", config.dst.root_dsn],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -120,64 +104,41 @@ async def test_main_workflow(setup_db_upgrade_config):
             break
     assert index_exists
 
-    # Run ANALYZE
-    await pgbelt.cmd.sync.analyze(
-        db=setup_db_upgrade_config.db, dc=setup_db_upgrade_config.dc
-    )
+    await _check_status(config, "replicating", "replicating")
 
-    # Revoke logins (TODO: test for this?)
-    await pgbelt.cmd.login.revoke_logins(
-        db=setup_db_upgrade_config.db, dc=setup_db_upgrade_config.dc
-    )
 
-    # Make sure forward says 'unconfigured' but reverse says 'replicating'
-    # ------------------------------------------------------------------
-    await pgbelt.cmd.teardown.teardown_forward_replication(
-        db=setup_db_upgrade_config.db, dc=setup_db_upgrade_config.dc
-    )
+async def _test_analyze(config):
+    await pgbelt.cmd.sync.analyze(db=config.db, dc=config.dc)
 
-    await pgbelt.cmd.status.status(db=None, dc=setup_db_upgrade_config.dc)
+    await _check_status(config, "replicating", "replicating")
 
-    status_echo_call_arg = pgbelt.cmd.status.echo.call_args[0][0]
 
-    # Regex for 2nd column (src -> dest) saying unconfigured, but 3rd (src <- dst) is replicating still
-    matches = re.findall(
-        r"^\S+\s+\S+unconfigured\S+\s+\S+replicating.*",
-        status_echo_call_arg.split("\n")[2],
-    )
-    assert len(matches) == 1
-    # ------------------------------------------------------------------
+async def _test_revoke_logins(config):
+    await pgbelt.cmd.login.revoke_logins(db=config.db, dc=config.dc)
 
-    # At this point, check sequence numbers? maybe
-    await pgbelt.cmd.sync.sync(
-        db=setup_db_upgrade_config.db, dc=setup_db_upgrade_config.dc
-    )
+    await _check_status(config, "replicating", "replicating")
 
-    # Make sure forward and back says 'unconfigured'
-    # ------------------------------------------------------------------
-    await pgbelt.cmd.teardown.teardown_back_replication(
-        db=setup_db_upgrade_config.db, dc=setup_db_upgrade_config.dc
-    )
 
-    await pgbelt.cmd.status.status(db=None, dc=setup_db_upgrade_config.dc)
+async def _test_teardown_forward_replication(config):
+    await pgbelt.cmd.teardown.teardown_forward_replication(db=config.db, dc=config.dc)
 
-    status_echo_call_arg = pgbelt.cmd.status.echo.call_args[0][0]
+    await _check_status(config, "unconfigured", "replicating")
 
-    # Regex for 2nd column (src -> dest) saying unconfigured, but 3rd (src <- dst) is replicating still
-    matches = re.findall(
-        r"^\S+\s+\S+unconfigured\S+\s+\S+unconfigured.*",
-        status_echo_call_arg.split("\n")[2],
-    )
-    assert len(matches) == 1
-    # ------------------------------------------------------------------
 
+async def _test_sync(config):
+    await pgbelt.cmd.sync.sync(db=config.db, dc=config.dc)
+
+    await _check_status(config, "unconfigured", "replicating")
+
+
+async def _ensure_same_data(config):
     # Dump the databases and ensure they're the same
     # Unfortunately except for the sequence lines because for some reason, the dump in the source is_called is true, yet on the destination is false.
     # Verified in the code we set it with is_called=True, so not sure what's going on there.
     # ------------------------------------------------------------------
 
     p = subprocess.Popen(
-        ["pg_dump", setup_db_upgrade_config.src.root_dsn],
+        ["pg_dump", config.src.root_dsn],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -208,7 +169,7 @@ async def test_main_workflow(setup_db_upgrade_config):
     source_dump = "\n".join(commands)
 
     p = subprocess.Popen(
-        ["pg_dump", setup_db_upgrade_config.dst.root_dsn],
+        ["pg_dump", config.dst.root_dsn],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -229,14 +190,78 @@ async def test_main_workflow(setup_db_upgrade_config):
 
     assert source_dump == dest_dump
 
-    # ------------------------------------------------------------------
 
-    # Run Teardown
+async def _test_teardown_not_full(config):
+    await pgbelt.cmd.teardown.teardown(db=config.db, dc=config.dc)
 
-    await pgbelt.cmd.teardown.teardown(
-        db=setup_db_upgrade_config.db, dc=setup_db_upgrade_config.dc
-    )
+    await _check_status(config, "unconfigured", "unconfigured")
 
-    await pgbelt.cmd.teardown.teardown(
-        db=setup_db_upgrade_config.db, dc=setup_db_upgrade_config.dc, full=True
-    )
+
+async def _test_teardown_full(config):
+    await pgbelt.cmd.teardown.teardown(db=config.db, dc=config.dc, full=True)
+
+    await _check_status(config, "unconfigured", "unconfigured")
+
+
+async def _test_main_workflow(config):
+    """
+    Run the following commands in order:
+
+    belt check-connectivity testdc && \
+    belt precheck testdc && \
+    belt setup testdc && \
+    belt setup-back-replication testdc && \
+    belt create-indexes testdc && \
+    belt analyze testdc && \
+    belt revoke-logins testdc && \
+    belt sync testdc && \
+    belt teardown testdc && \
+    belt teardown testdc --full
+    """
+
+    await _test_check_connectivity(config)
+    await _test_precheck(config)
+    await _test_setup(config)
+    await _test_setup_back_replication(config)
+    await _test_create_indexes(config)
+    await _test_analyze(config)
+    await _test_revoke_logins(config)
+    await _test_teardown_forward_replication(config)
+    await _test_sync(config)
+
+    # Check if the data is the same before testing teardown
+    await _ensure_same_data(config)
+
+    await _test_teardown_not_full(config)
+    await _test_teardown_full(config)
+
+
+# Run the main integration test with objects in the public schema
+@pytest.mark.asyncio
+async def test_main_workflow_public_schema(setup_db_upgrade_config_public_schema):
+
+    await _test_main_workflow(setup_db_upgrade_config_public_schema)
+
+
+# Run the main integration test with objects in a non-public schema
+@pytest.mark.asyncio
+async def test_main_workflow_non_public_schema(
+    setup_db_upgrade_config_non_public_schema,
+):
+
+    await _test_main_workflow(setup_db_upgrade_config_non_public_schema)
+
+
+# TODO: fix up the exodus-style tests, the dump comparision step obviously fails because not all data was moved.
+# # Run the main integration test with objects in a non-public schema and exodus-style (moving a subset of data)
+# @pytest.mark.asyncio
+# async def test_main_workflow_public_schema_exodus(setup_db_upgrade_config_public_schema_exodus):
+
+#     await _test_main_workflow(setup_db_upgrade_config_public_schema_exodus)
+
+# TODO: fix up the exodus-style tests, the dump comparision step obviously fails because not all data was moved.
+# # Run the main integration test with objects in a non-public schema and exodus-style (moving a subset of data)
+# @pytest.mark.asyncio
+# async def test_main_workflow_non_public_schema_exodus(setup_db_upgrade_config_non_public_schema_exodus):
+
+#     await _test_main_workflow(setup_db_upgrade_config_non_public_schema_exodus)


### PR DESCRIPTION
This includes a big refactor on the integration test, to make it modular for multiplexing the workflow against various test cases.

This PR is missing the following, which may be just filed as separate issues:
- Parallelization of the integration tests - this needs some thought (especially on how to collect all the output in a legible way)
- Finishing up the Exodus tests - they won't pass in the current state because we do a total dump comparison between the source and destination. Exodus implies that only a subset of data gets migrated, so the test needs to support that.