### PR TITLE
refactor: all but one deprecation warning eliminated

### DIFF
--- a/pgbelt/config/models.py
+++ b/pgbelt/config/models.py
@@ -9,7 +9,7 @@ from pgbelt.util import get_logger
 from pgbelt.util.asyncfuncs import makedirs
 from pydantic import BaseModel
 from pydantic import ValidationError
-from pydantic import validator
+from pydantic import field_validator
 
 
 def config_dir(db: str, dc: str) -> str:
@@ -37,7 +37,7 @@ class User(BaseModel):
     name: str
     pw: Optional[str] = None
 
-    _not_empty = validator("name", "pw", allow_reuse=True)(not_empty)
+    _not_empty = field_validator("name", "pw")(not_empty)
 
 
 class DbConfig(BaseModel):
@@ -64,9 +64,9 @@ class DbConfig(BaseModel):
     pglogical_user: User
     other_users: Optional[list[User]] = None
 
-    _not_empty = validator("host", "ip", "db", "port", allow_reuse=True)(not_empty)
+    _not_empty = field_validator("host", "ip", "db", "port")(not_empty)
 
-    @validator("root_user", "owner_user", "pglogical_user")
+    @field_validator("root_user", "owner_user", "pglogical_user")
     def has_password(cls, v) -> User:  # noqa: N805
         if not v.pw:
             raise ValueError
@@ -118,7 +118,7 @@ class DbupgradeConfig(BaseModel):
     sequences: Optional[list[str]] = None
     schema_name: Optional[str] = "public"
 
-    _not_empty = validator("db", "dc", allow_reuse=True)(not_empty)
+    _not_empty = field_validator("db", "dc")(not_empty)
 
     @property
     def file(self) -> str:
@@ -167,7 +167,7 @@ class DbupgradeConfig(BaseModel):
             return None
 
         try:
-            out = cls.parse_raw(raw)
+            out = cls.model_validate_json(raw)
         except ValidationError:
             logger.info("Cached config was not a valid DbupgradeConfig")
             return None

--- a/pgbelt/config/remote.py
+++ b/pgbelt/config/remote.py
@@ -79,7 +79,7 @@ async def load_remote_conf_def(
         async with aopen(config_file, mode="r") as f:
             raw_json = await f.read()
 
-        return RemoteConfigDefinition.parse_raw(raw_json)
+        return RemoteConfigDefinition.model_validate_json(raw_json)
     except FileNotFoundError:
         logger.error(f"No remote config definition exists at {config_file}")
     except JSONDecodeError:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,8 +1,6 @@
 from os import environ
-from sys import argv
 from shutil import rmtree
 
-import pytest
 import pytest_asyncio
 import asyncio
 from asyncpg import create_pool
@@ -216,7 +214,6 @@ async def _empty_out_databases(configs: dict[str, DbupgradeConfig]) -> None:
                 )
 
 
-@pytest.mark.asyncio
 @pytest_asyncio.fixture
 async def setup_db_upgrade_configs():
     """

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -301,7 +301,7 @@ async def _ensure_same_data(configs: dict[str, DbupgradeConfig]):
                         src_table_data[table] = src_table_data[table] + line + "\n"
                     elif len(src_table_data[table]) > 0:
                         src_table_data[table] = src_table_data[table] + line + "\n"
-                        if line == "\.":
+                        if line == "\\.":
                             break
             dst_table_data = {}
             for table in configs[setname].tables:
@@ -311,7 +311,7 @@ async def _ensure_same_data(configs: dict[str, DbupgradeConfig]):
                         dst_table_data[table] = dst_table_data[table] + line + "\n"
                     elif len(dst_table_data[table]) > 0:
                         dst_table_data[table] = dst_table_data[table] + line + "\n"
-                        if line == "\.":
+                        if line == "\\.":
                             break
 
             # Ensure the targeted data is the same


### PR DESCRIPTION
Only the following is left:
```
../venv/lib/python3.11/site-packages/pydantic/_internal/_config.py:272
../venv/lib/python3.11/site-packages/pydantic/_internal/_config.py:272
  /opt/venv/lib/python3.11/site-packages/pydantic/_internal/_config.py:272: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.6/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)
```