### PR TITLE
fix: support for capital letters in sequence names

### DIFF
--- a/pgbelt/util/postgres.py
+++ b/pgbelt/util/postgres.py
@@ -15,9 +15,9 @@ async def dump_sequences(
     # Get all sequences in the schema
     seqs = await pool.fetch(
         f"""
-        SELECT '{schema}' || '.' || sequence_name
+        SELECT '{schema}' || '.\"' || sequence_name
         FROM information_schema.sequences
-        WHERE sequence_schema = '{schema}';
+        WHERE sequence_schema = '{schema}' || '\"';
         """
     )
 
@@ -28,7 +28,7 @@ async def dump_sequences(
         proper_sequence_names = []
         for seq in targeted_sequences:
             if f"{schema}." not in seq:
-                proper_sequence_names.append(f"{schema}.{seq}")
+                proper_sequence_names.append(f'{schema}."{seq}"')
             else:
                 proper_sequence_names.append(seq)
     targeted_sequences = proper_sequence_names

--- a/tests/integration/files/test_schema_data.sql
+++ b/tests/integration/files/test_schema_data.sql
@@ -31,7 +31,7 @@ ALTER TABLE public."UsersCapital" OWNER TO owner;
 
 CREATE TABLE public."UsersCapital2" (
     id bigint NOT NULL,
-    hash_firstname text NOT NULL,
+    "hash_firstName" text NOT NULL,
     hash_lastname text NOT NULL,
     gender character varying(6) NOT NULL,
     CONSTRAINT users_gender_check CHECK (((gender)::text = ANY (ARRAY[('male'::character varying)::text, ('female'::character varying)::text])))
@@ -62,7 +62,7 @@ CREATE INDEX users2_idx ON public."UsersCapital" (
 -- Name: userS_id_seq; Type: SEQUENCE; Schema: public; Owner: owner
 --
 
-CREATE SEQUENCE public.userS_id_seq
+CREATE SEQUENCE public."userS_id_seq"
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -70,7 +70,7 @@ CREATE SEQUENCE public.userS_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.userS_id_seq OWNER TO owner;
+ALTER TABLE public."userS_id_seq" OWNER TO owner;
 
 --
 -- Name: users2_id_seq; Type: SEQUENCE; Schema: public; Owner: owner
@@ -111,7 +111,7 @@ INSERT INTO public."UsersCapital" (id, hash_firstname, hash_lastname, gender)
 -- Data for Name: Users2; Type: TABLE DATA; Schema: public; Owner: owner
 --
 
-INSERT INTO public."UsersCapital2" (id, hash_firstname, hash_lastname, gender)
+INSERT INTO public."UsersCapital2" (id, "hash_firstName", hash_lastname, gender)
     VALUES (1, 'garbagefirst', 'garbagelast', 'male'),
     (2, 'garbagefirst1', 'garbagelast1', 'female'),
     (3, 'sdgarbagefirst', 'dgsadsrbagelast', 'male'),
@@ -123,7 +123,7 @@ INSERT INTO public."UsersCapital2" (id, hash_firstname, hash_lastname, gender)
 -- Name: userS_id_seq; Type: SEQUENCE SET; Schema: public; Owner: owner
 --
 
-SELECT pg_catalog.setval('public.userS_id_seq', 1, false);
+SELECT pg_catalog.setval('public."userS_id_seq"', 1, false);
 
 
 --


### PR DESCRIPTION
Problem:

Capitals in Sequence Names would yield errors like `relation "non_public_schema.users_id_seq" does not exist` for a sequence named `userS_id_seq`. Previously we thought the integration test covered this but the schema SQL didn't wrap the sequence names in quotes.

Solved it in this PR! Integration test works!