### PR TITLE
fix: support for capital sequences and better sequence testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,15 +14,15 @@ setup: ## Install development requirements. You should be in a virtualenv
 	poetry install && pre-commit install
 
 test: ## Run tests
-	docker build . -t autodesk/pgbelt:latest && docker build tests/integration/files/postgres13-pglogical-docker/ -t autodesk/postgres-pglogical-docker:13 && docker-compose run tests
+	docker build . -t autodesk/pgbelt:latest && docker build tests/integration/files/postgres13-pglogical-docker/ -t autodesk/postgres-pglogical-docker:13 && docker compose run tests
 
 tests: test
 
 local-dev: ## Sets up docker containers for Postgres DBs and gets you into a docker container with pgbelt installed. DC: testdc, DB: testdb
-	docker build . -t autodesk/pgbelt:latest && docker build tests/integration/files/postgres13-pglogical-docker/ -t autodesk/postgres-pglogical-docker:13 && docker-compose run localtest
+	docker build . -t autodesk/pgbelt:latest && docker build tests/integration/files/postgres13-pglogical-docker/ -t autodesk/postgres-pglogical-docker:13 && docker compose run localtest
 
 clean-docker: ## Stop and remove all docker containers and images made from local testing
-	docker stop $$(docker ps -aq --filter name=^/pgbelt) && docker rm $$(docker ps -aq --filter name=^/pgbelt) && docker-compose down --rmi all
+	docker stop $$(docker ps -aq --filter name=^/pgbelt) && docker rm $$(docker ps -aq --filter name=^/pgbelt) && docker compose down --rmi all
 
 # Note: typer-cli has dependency conflict issues that don't affect it generating docs, see https://github.com/tiangolo/typer-cli/pull/120.
 # We need to install the package with pip instead. Then, we run pre-commit to fix the formatting of the generated file.

--- a/pgbelt/cmd/sync.py
+++ b/pgbelt/cmd/sync.py
@@ -30,7 +30,7 @@ async def _sync_sequences(
 ) -> None:
 
     seq_vals = await dump_sequences(src_pool, targeted_sequences, schema, src_logger)
-    await load_sequences(dst_pool, seq_vals, dst_logger)
+    await load_sequences(dst_pool, seq_vals, schema, dst_logger)
 
 
 @run_with_configs

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -55,7 +55,7 @@ async def _create_dbupgradeconfigs() -> dict[str, DbupgradeConfig]:
         )
         db_upgrade_config_kwargs["tables"] = ["UsersCapital"] if "exodus" in s else None
         db_upgrade_config_kwargs["sequences"] = (
-            ["users_id_seq"] if "exodus" in s else None
+            ["userS_id_seq"] if "exodus" in s else None
         )
         config = DbupgradeConfig(**db_upgrade_config_kwargs)
 

--- a/tests/integration/files/test_schema_data.sql
+++ b/tests/integration/files/test_schema_data.sql
@@ -123,14 +123,14 @@ INSERT INTO public."UsersCapital2" (id, "hash_firstName", hash_lastname, gender)
 -- Name: userS_id_seq; Type: SEQUENCE SET; Schema: public; Owner: owner
 --
 
-SELECT pg_catalog.setval('public."userS_id_seq"', 1, false);
+SELECT pg_catalog.setval('public."userS_id_seq"', 16, false);
 
 
 --
 -- Name: users2_id_seq; Type: SEQUENCE SET; Schema: public; Owner: owner
 --
 
-SELECT pg_catalog.setval('public.users2_id_seq', 1, false);
+SELECT pg_catalog.setval('public.users2_id_seq', 15, false);
 
 
 --


### PR DESCRIPTION
v0.7.7 causes sequence dumps to go empty due to complications with schema names and the capitalization issue from #548.

This fixes all of that, and ensures testing is done via PSQL directly instead of internal functions.