### PR TITLE
fix: add timestamps to logs DBAAS-92

### DIFF
--- a/pgbelt/util/logs.py
+++ b/pgbelt/util/logs.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 from os import getenv
 from os import makedirs
 

--- a/pgbelt/util/logs.py
+++ b/pgbelt/util/logs.py
@@ -1,14 +1,16 @@
 import logging
+import sys
 from os import getenv
 from os import makedirs
 
 
-FORMATTER = "{name}:{levelname} {message}"
+FORMATTER = "{asctime} {name}:{levelname} {message}"
 
 # if this module is ever imported we set up the root logger to log to stderr
 root_level = int(getenv("LOG_LEVEL", logging.DEBUG))
 root_handler = logging.StreamHandler()
-root_handler.setFormatter(logging.Formatter(FORMATTER, style="{"))
+formatter = logging.Formatter(fmt=FORMATTER, style='{', datefmt='%Y-%m-%d %H:%M:%S')
+root_handler.setFormatter(formatter)
 root_handler.setLevel(root_level)
 root_logger = logging.getLogger("dbup")
 root_logger.setLevel(root_level)
@@ -41,7 +43,7 @@ def get_logger(db: str, dc: str, kind: str = "") -> logging.Logger:
 
         if not skip_file_handler:
             handler = logging.FileHandler(log_file_path(db, dc), mode="w")
-            handler.setFormatter(logging.Formatter(FORMATTER, style="{"))
+            handler.setFormatter(logging.Formatter(FORMATTER, style="{"), datefmt='%Y-%m-%d %H:%M:%S')
             # always log everything to the file
             logger.setLevel(logging.DEBUG)
             logger.addHandler(handler)

--- a/pgbelt/util/logs.py
+++ b/pgbelt/util/logs.py
@@ -8,7 +8,7 @@ FORMATTER = "{asctime} {name}:{levelname} {message}"
 # if this module is ever imported we set up the root logger to log to stderr
 root_level = int(getenv("LOG_LEVEL", logging.DEBUG))
 root_handler = logging.StreamHandler()
-formatter = logging.Formatter(fmt=FORMATTER, style='{', datefmt='%Y-%m-%d %H:%M:%S')
+formatter = logging.Formatter(fmt=FORMATTER, datefmt='%Y-%m-%d %H:%M:%S', style='{')
 root_handler.setFormatter(formatter)
 root_handler.setLevel(root_level)
 root_logger = logging.getLogger("dbup")
@@ -42,7 +42,7 @@ def get_logger(db: str, dc: str, kind: str = "") -> logging.Logger:
 
         if not skip_file_handler:
             handler = logging.FileHandler(log_file_path(db, dc), mode="w")
-            handler.setFormatter(logging.Formatter(FORMATTER, style="{"), datefmt='%Y-%m-%d %H:%M:%S')
+            handler.setFormatter(logging.Formatter(FORMATTER, datefmt='%Y-%m-%d %H:%M:%S', style="{"))
             # always log everything to the file
             logger.setLevel(logging.DEBUG)
             logger.addHandler(handler)


### PR DESCRIPTION
Fixes #557

In ipython:
import pgbelt.util.logs

logger = logs.get_logger("dba", "dcb")

logger.info('d message')
2024-09-17 11:26:53 dbup.dba.dcb:INFO d message

DBAAS-92