### PR TITLE
ci: move to new release-please gha repo

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,7 +7,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.PGBELT_GHA_VJEEVA_PAT }}
           release-type: python


### PR DESCRIPTION
Updating due to https://github.com/Autodesk/pgbelt/actions/runs/11276987149/job/31362090071

```
Warning: google-github-actions/release-please-action is deprecated, please use googleapis/release-please-action instead.
```

