### PR TITLE
feat: advanced extension migration checks for precheck #813

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,4 +63,3 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
-      - id: ruff-format

--- a/pgbelt/util/postgres.py
+++ b/pgbelt/util/postgres.py
@@ -172,7 +172,6 @@ async def compare_data(
         # Check each row for exact match
         for src_row, dst_row in zip(src_rows, dst_rows):
             if src_row != dst_row:
-
                 # Addresses #571, AsyncPG is decoding numeric NaN as Python Decimal('NaN').
                 # Decimal('NaN') != Decimal('NaN'), breaks comparison. Convert those NaNs to None.
                 src_row_d = {
@@ -411,7 +410,6 @@ async def precheck_info(
 
     # We filter the table list if the user has specified a list of tables to target.
     if target_tables:
-
         result["tables"] = [t for t in result["tables"] if t["Name"] in target_tables]
 
         # We will not recapitalize the table names in the result["tables"] list,
@@ -437,7 +435,6 @@ async def precheck_info(
 
     # We filter the table list if the user has specified a list of tables to target.
     if target_sequences:
-
         result["sequences"] = [
             t for t in result["sequences"] if t["Name"] in target_sequences
         ]
@@ -471,15 +468,23 @@ async def precheck_info(
         if u[0] == owner_name:
             result["users"]["owner"] = u
 
-    result["extensions"] = await pool.fetch(
+    result["extensions"] = await fetch_extensions(pool)
+
+    return result
+
+
+async def fetch_extensions(pool: Pool) -> list[str]:
+    """
+    Return a sorted list of installed extension names for the current database.
+    """
+    rows = await pool.fetch(
         """
         SELECT extname
         FROM pg_extension
         ORDER BY extname;
         """
     )
-
-    return result
+    return [row["extname"] for row in rows]
 
 
 # TODO: Need to add schema here when working on non-public schema support.


### PR DESCRIPTION
Technically a fix due to Postgres changes, but shipping as a feature since it is a more advanced check now!

It now compares extensions in the logical DB and root DB separately, and also now has a way to check for extensions that might have moved from a logical DB to a root DB over a major version change!!!

<img width="1772" height="438" alt="image" src="https://github.com/user-attachments/assets/d479f472-faf7-42d9-87de-84245850aff0" />

Fixes #813 

