### PR TITLE
fix: add side field to BaseSideResolver, inject in framework

### DIFF
--- a/pgbelt/config/remote.py
+++ b/pgbelt/config/remote.py
@@ -121,6 +121,7 @@ class BaseSideResolver(BaseModel):
 
     db: str the database pair name
     dc: str the datacenter / project name
+    side: str "src" or "dst" -- set by the framework, not the user
     logger: Logger your resolver should log through this logger
 
     Your resolver subclass will be a pydantic model. Any attributes you define
@@ -130,6 +131,7 @@ class BaseSideResolver(BaseModel):
 
     db: str
     dc: str
+    side: str
     logger: Logger
 
     class Config:
@@ -186,6 +188,7 @@ async def _resolve_side(
         resolver = cls(
             db=db,
             dc=dc,
+            side=side_label,
             logger=logger.getChild(cls.__name__),
             **resolver_config,
         )


### PR DESCRIPTION
## Summary
- Adds `side: str` to `BaseSideResolver` so resolvers know which side they're resolving for
- Framework (`_resolve_side`) now passes `side=side_label` automatically when constructing resolvers
- Subclasses no longer need to declare their own `side` field with a default

## Motivation
Resolvers need to know their side for side-specific operations (e.g. naming SSM pglogical password paths as `PGL_PW_SRC` vs `PGL_PW_DST`). Previously each subclass had to declare `side: str = "src"` which was error-prone. Now the framework injects it.

## Test plan
- [x] Existing pgbelt resolver tests pass (18/18)
- [ ] Verify DacloudSideResolver and PushedSecretSideResolver work without their own side field
