### PR TITLE
feat: diff-sequences per-DB table, JSON, and root connections

### DIFF
--- a/pgbelt/cmd/helpers.py
+++ b/pgbelt/cmd/helpers.py
@@ -34,6 +34,9 @@ from pgbelt.models.schema import IndexDetail
 from pgbelt.models.status import ReplicationLag
 from pgbelt.models.status import StatusResult
 from pgbelt.models.status import StatusRow
+from pgbelt.models.sync import DiffSequencesResult
+from pgbelt.models.sync import DiffSequencesRow
+from pgbelt.models.sync import SequenceCompareDetail
 from pgbelt.models.sync import SequenceSyncDetail
 from pgbelt.models.sync import SyncSequencesResult
 from pgbelt.models.sync import SyncTablesResult
@@ -301,6 +304,34 @@ def _build_diff_schemas_result(
     )
 
 
+def _build_diff_sequences_result(
+    results: list[dict], base_kwargs: dict
+) -> DiffSequencesResult:
+    db_rows: list[DiffSequencesRow] = []
+    for r in results:
+        if not isinstance(r, dict):
+            continue
+        seqs = [
+            SequenceCompareDetail(**s)
+            for s in r.get("sequences", [])
+            if isinstance(s, dict)
+        ]
+        db_rows.append(
+            DiffSequencesRow(
+                db=r.get("db", ""),
+                schema_name=r.get("schema_name"),
+                sequences=seqs,
+                result=r.get("result", "mismatch"),
+            )
+        )
+    all_match = all(row.result == "match" for row in db_rows)
+    return DiffSequencesResult(
+        success=all_match,
+        results=db_rows,
+        **base_kwargs,
+    )
+
+
 _RICH_MODEL_BUILDERS: dict[str, Callable] = {
     "check-connectivity": _build_connectivity_result,
     "connections": _build_connections_result,
@@ -311,6 +342,7 @@ _RICH_MODEL_BUILDERS: dict[str, Callable] = {
     "validate-data": _build_validate_data_result,
     "create-indexes": _build_create_indexes_result,
     "diff-schemas": _build_diff_schemas_result,
+    "diff-sequences": _build_diff_sequences_result,
 }
 
 

--- a/pgbelt/cmd/sync.py
+++ b/pgbelt/cmd/sync.py
@@ -1,5 +1,6 @@
 from asyncio import gather
 from collections.abc import Awaitable
+from decimal import Decimal
 from logging import Logger
 from typing import Any
 
@@ -21,7 +22,18 @@ from pgbelt.util.postgres import dump_sequences
 from pgbelt.util.postgres import load_sequences
 from pgbelt.util.postgres import run_analyze
 from pgbelt.util.postgres import set_pk_sequences_from_data
+from tabulate import tabulate
+from typer import echo
 from typer import Option
+from typer import style
+
+
+def _sequence_value_as_int(val: Any) -> int | None:
+    if val is None:
+        return None
+    if isinstance(val, Decimal):
+        return int(val)
+    return int(val)
 
 
 async def _sync_sequences(
@@ -359,10 +371,99 @@ async def sync(
         await gather(*[p.close() for p in pools])
 
 
+async def _print_diff_sequences_table(results: list[dict[str, Any]]) -> None:
+    first_db = True
+    for r in sorted(results, key=lambda d: d.get("db", "")):
+        if not first_db:
+            echo("")
+        first_db = False
+        echo(style(r.get("db", ""), "green"))
+        table: list[list[Any]] = [
+            [
+                style("sequence", "yellow"),
+                style("SRC", "yellow"),
+                style("DST", "yellow"),
+            ]
+        ]
+        for row in sorted(r.get("sequences", []), key=lambda x: x["name"]):
+            src_v = row.get("source_value")
+            dst_v = row.get("destination_value")
+            dst_ok = row.get("destination_ok", False)
+            src_cell = str(src_v) if src_v is not None else "—"
+            if dst_v is None:
+                dst_cell = style("—", "yellow")
+            else:
+                dst_cell = style(str(dst_v), "green" if dst_ok else "red")
+            table.append([row["name"], src_cell, dst_cell])
+        echo(tabulate(table, headers="firstrow"))
+
+
+@run_with_configs(results_callback=_print_diff_sequences_table)
+async def diff_sequences(
+    config_future: Awaitable[DbupgradeConfig],
+) -> dict[str, Any]:
+    """
+    Compare source and destination sequence last_value for each targeted sequence.
+
+    Destination values are highlighted green when they are greater than or equal to
+    source, and red otherwise.
+
+    Requires both src and dst to be not null in the config file.
+
+    If the db name is not given, runs for every database in the datacenter (same
+    pattern as ``diff-schemas``).
+    """
+    conf = await config_future
+    logger = get_logger(conf.db, conf.dc, "sync.diff_sequences")
+    pools = await gather(
+        create_pool(conf.src.pglogical_uri, min_size=1),
+        create_pool(conf.dst.root_uri, min_size=1),
+    )
+    src_pool, dst_pool = pools
+    try:
+        src_map, dst_map = await gather(
+            dump_sequences(src_pool, conf.sequences, conf.schema_name, logger),
+            dump_sequences(dst_pool, conf.sequences, conf.schema_name, logger),
+        )
+    finally:
+        await gather(*[p.close() for p in pools])
+
+    names = sorted(set(src_map.keys()) | set(dst_map.keys()))
+    sequences_out: list[dict[str, Any]] = []
+    for name in names:
+        sv = _sequence_value_as_int(src_map.get(name))
+        dv = _sequence_value_as_int(dst_map.get(name))
+        if sv is not None and dv is not None:
+            dst_ok = dv >= sv
+        elif sv is None and dv is not None:
+            dst_ok = True
+        elif sv is not None and dv is None:
+            dst_ok = False
+        else:
+            dst_ok = True
+        sequences_out.append(
+            {
+                "name": name,
+                "source_value": sv,
+                "destination_value": dv,
+                "destination_ok": dst_ok,
+            }
+        )
+
+    overall = "match" if all(s["destination_ok"] for s in sequences_out) else "mismatch"
+    return {
+        "db": conf.db,
+        "schema_name": conf.schema_name,
+        "sequences": sequences_out,
+        "result": overall,
+    }
+
+
 COMMANDS = [
     sync_sequences,
     sync_tables,
     analyze,
     validate_data,
     sync,
+    diff_sequences,
 ]

--- a/pgbelt/cmd/sync.py
+++ b/pgbelt/cmd/sync.py
@@ -405,6 +405,9 @@ async def diff_sequences(
     """
     Compare source and destination sequence last_value for each targeted sequence.
 
+    Uses the **root** database user on both source and destination (same as
+    ``diff-schemas``), not the pglogical user.
+
     Destination values are highlighted green when they are greater than or equal to
     source, and red otherwise.
 
@@ -416,7 +419,7 @@ async def diff_sequences(
     conf = await config_future
     logger = get_logger(conf.db, conf.dc, "sync.diff_sequences")
     pools = await gather(
-        create_pool(conf.src.pglogical_uri, min_size=1),
+        create_pool(conf.src.root_uri, min_size=1),
         create_pool(conf.dst.root_uri, min_size=1),
     )
     src_pool, dst_pool = pools

--- a/pgbelt/models/__init__.py
+++ b/pgbelt/models/__init__.py
@@ -36,9 +36,12 @@ from pgbelt.models.schema import DiffSchemasResult
 from pgbelt.models.schema import IndexDetail
 from pgbelt.models.status import StatusResult
 from pgbelt.models.status import StatusRow
+from pgbelt.models.sync import SequenceCompareDetail
 from pgbelt.models.sync import SyncSequencesResult
 from pgbelt.models.sync import SyncTablesResult
 from pgbelt.models.sync import ValidateDataResult
+from pgbelt.models.sync import DiffSequencesResult
+from pgbelt.models.sync import DiffSequencesRow
 
 __all__ = [
     # Base -- used directly by simple commands (setup, teardown, analyze, etc.)
@@ -60,6 +63,9 @@ __all__ = [
     "IndexDetail",
     "StatusResult",
     "StatusRow",
+    "SequenceCompareDetail",
+    "DiffSequencesResult",
+    "DiffSequencesRow",
     "SyncSequencesResult",
     "SyncTablesResult",
     "ValidateDataResult",

--- a/pgbelt/models/sync.py
+++ b/pgbelt/models/sync.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Optional
 
 from pydantic import BaseModel
+from pydantic import computed_field
 
 from pgbelt.models.base import CommandResult
 
@@ -16,6 +17,36 @@ class SequenceSyncDetail(BaseModel):
     synced: bool
     method: str  # "pk_max" | "source_value" | "source_value_with_stride"
     skipped_reason: Optional[str] = None
+
+
+class SequenceCompareDetail(BaseModel):
+    """One sequence row in ``belt diff-sequences`` output."""
+
+    name: str
+    source_value: Optional[int] = None
+    destination_value: Optional[int] = None
+    destination_ok: bool = False
+
+
+class DiffSequencesRow(BaseModel):
+    """Per-database sequence comparison summary."""
+
+    db: str
+    schema_name: Optional[str] = None
+    sequences: list[SequenceCompareDetail] = []
+    result: str = "mismatch"  # "match" | "mismatch"
+
+
+class DiffSequencesResult(CommandResult):
+    """JSON output for ``belt diff-sequences``."""
+
+    command: str = "diff-sequences"
+    results: list[DiffSequencesRow] = []
+
+    @computed_field
+    @property
+    def all_match(self) -> bool:
+        return all(r.result == "match" for r in self.results)
 
 
 class SyncSequencesResult(CommandResult):

--- a/tests/pgbelt/cmd/test_json_flag.py
+++ b/tests/pgbelt/cmd/test_json_flag.py
@@ -15,6 +15,7 @@ from pgbelt.models.preflight import PrecheckResult
 from pgbelt.models.schema import CreateIndexesResult
 from pgbelt.models.schema import DiffSchemasResult
 from pgbelt.models.status import StatusResult
+from pgbelt.models.sync import DiffSequencesResult
 from pgbelt.models.sync import SyncSequencesResult
 from pgbelt.models.sync import SyncTablesResult
 from pgbelt.models.sync import ValidateDataResult
@@ -699,6 +700,97 @@ class TestBuildJsonOutputRichModels:
         assert result.success is False
         assert result.all_match is False
         assert len(result.results) == 3
+
+    def test_diff_sequences_match(self):
+        output = _build_json_output(
+            command_name="diff-sequences",
+            dc="dc1",
+            db="db1",
+            results=[
+                {
+                    "db": "db1",
+                    "schema_name": "public",
+                    "sequences": [
+                        {
+                            "name": "s1",
+                            "source_value": 10,
+                            "destination_value": 12,
+                            "destination_ok": True,
+                        },
+                        {
+                            "name": "s2",
+                            "source_value": 5,
+                            "destination_value": 5,
+                            "destination_ok": True,
+                        },
+                    ],
+                    "result": "match",
+                }
+            ],
+            success=True,
+            duration_ms=200,
+        )
+        result = DiffSequencesResult.model_validate_json(output)
+        assert result.command == "diff-sequences"
+        assert result.success is True
+        assert result.all_match is True
+        assert result.results[0].result == "match"
+        assert result.results[0].sequences[0].destination_ok is True
+
+    def test_diff_sequences_mismatch(self):
+        output = _build_json_output(
+            command_name="diff-sequences",
+            dc="dc1",
+            db="db1",
+            results=[
+                {
+                    "db": "db1",
+                    "schema_name": "app",
+                    "sequences": [
+                        {
+                            "name": "s1",
+                            "source_value": 100,
+                            "destination_value": 50,
+                            "destination_ok": False,
+                        },
+                    ],
+                    "result": "mismatch",
+                }
+            ],
+            success=True,
+            duration_ms=100,
+        )
+        result = DiffSequencesResult.model_validate_json(output)
+        assert result.success is False
+        assert result.all_match is False
+
+    def test_diff_sequences_multi_db(self):
+        output = _build_json_output(
+            command_name="diff-sequences",
+            dc="dc1",
+            db=None,
+            results=[
+                {"db": "db1", "schema_name": "p", "sequences": [], "result": "match"},
+                {
+                    "db": "db2",
+                    "schema_name": "p",
+                    "sequences": [
+                        {
+                            "name": "a",
+                            "source_value": 1,
+                            "destination_value": 0,
+                            "destination_ok": False,
+                        }
+                    ],
+                    "result": "mismatch",
+                },
+            ],
+            success=True,
+            duration_ms=300,
+        )
+        result = DiffSequencesResult.model_validate_json(output)
+        assert result.success is False
+        assert len(result.results) == 2
 
     def test_error_falls_back_to_generic(self):
         """When an error occurs, even rich commands use generic CommandResult."""


### PR DESCRIPTION
## Summary
- `belt diff-sequences` prints a **sequence / SRC / DST** table per database, with **DST** in **green** when `DST >= SRC` and **red** otherwise.
- **Multi-DB** runs (no DB arg) print one table per DB, **sorted by DB name**, with a blank line between sections.
- `--json`: new `DiffSequencesResult` / `DiffSequencesRow` / `SequenceCompareDetail` models, builder, and `test_json_flag` coverage.
- Closes connection pools after the check; coerces `Decimal` sequence values to int for comparison.
- **Source connection uses `root_uri` (not pglogical)**, matching `diff-schemas` and avoiding pglogical auth in environments where only root is configured.

## Context
Supports post–`sync-sequences` validation (e.g. **STOPS-7626**): destination `last_value` should be at least the source so new writes on DST do not collide with replicated data.

## Testing
- `pytest tests/pgbelt/cmd/test_json_flag.py` (diff-sequences JSON cases)


Made with [Cursor](https://cursor.com)