### PR TITLE
fix(tests): await _compare_sequences in integration test

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -461,7 +461,7 @@ async def _ensure_same_data(configs: dict[str, DbupgradeConfig]):
                 f"Ensuring {setname} source and destination sequences are the same..."
             )
 
-            _compare_sequences(
+            await _compare_sequences(
                 configs[
                     setname
                 ].sequences,  # In exodus-style migrations, we have our sequences defined in the config
@@ -496,7 +496,7 @@ async def _ensure_same_data(configs: dict[str, DbupgradeConfig]):
                 .split("\n")
             )
 
-            _compare_sequences(
+            await _compare_sequences(
                 sequences,  # In full migrations, we need to get the sequences from the source database
                 configs[setname].src.root_dsn,
                 configs[setname].dst.root_dsn,


### PR DESCRIPTION
## Summary
`_compare_sequences` is `async def` and contains the only assertion that verifies src and dst sequence values match (`assert src_val == dst_val` at [test_integration.py:356](tests/integration/test_integration.py#L356)). Both call sites in `_ensure_same_data` invoked it without `await`, so the resulting coroutine object was discarded and the assertion never ran.

This means the integration test's claim that "sequences match after sync" was never actually verified — including for the camelCase `userS_id_seq` PK sequence the fixtures explicitly target. Python emits `RuntimeWarning: coroutine '_compare_sequences' was never awaited` but pytest doesn't fail the run on it.

## Fix
Add `await` to both call sites:
- exodus-style path ([test_integration.py:464](tests/integration/test_integration.py#L464))
- full-migration path ([test_integration.py:499](tests/integration/test_integration.py#L499))

## Discovered while
Validating the new `diff-sequences` gate downstream (in pgbaas STOPS-7626) — production migration test correctly caught a real `userS_id_seq` mismatch (`dst_last=5, src_last=16`), which raised the question of why pgbelt's own integration test wasn't catching it. Turns out it never could.

## Test plan
- [ ] CI runs the integration test with the now-active assertion and still passes (i.e. sync-sequences in CI's exodus and full paths produces matching seq values)
- [ ] If CI fails, that itself is the value — it'd surface a real sync-sequences regression that was previously masked