### PR TITLE
fix(check-connectivity): probe owner credentials with a 10s SELECT 1

### DIFF
--- a/pgbelt/cmd/convenience.py
+++ b/pgbelt/cmd/convenience.py
@@ -7,6 +7,7 @@ from asyncio import wait_for
 from collections.abc import Awaitable
 from logging import Logger
 
+import asyncpg
 from asyncpg import create_pool
 from pgbelt.cmd.helpers import run_with_configs
 from pgbelt.config.config import get_config
@@ -19,6 +20,15 @@ from tabulate import tabulate
 from typer import echo
 from typer import Option
 from typer import style
+
+# Short connect+query timeout used for the owner-credential probe.
+# A healthy asyncpg connect against RDS completes in <500ms even
+# cross-account; 10s is comfortably above that and 6x faster than
+# asyncpg's 60s default ``connect_timeout``, so a server that silently
+# closes a bad-password connection (which is what RDS does) still
+# surfaces a structured failure on the connectivity grid instead of
+# wedging the SFN at the next belt stage.
+_OWNER_PROBE_TIMEOUT_SECONDS = 10.0
 
 
 def src_dsn(
@@ -98,9 +108,11 @@ async def _print_connectivity_results(results: list[dict]):
             style("database", "yellow"),
             style("src tcp ok", "yellow"),
             style("src query ok", "yellow"),
+            style("src owner ok", "yellow"),
             style("src->dst dblink ok", "yellow"),
             style("dst tcp ok", "yellow"),
             style("dst query ok", "yellow"),
+            style("dst owner ok", "yellow"),
             style("dst->src dblink ok", "yellow"),
         ]
     ]
@@ -115,11 +127,19 @@ async def _print_connectivity_results(results: list[dict]):
                 style(r["src_tcp"], "green" if r["src_tcp"] else "red"),
                 style(r["src_query"], "green" if r["src_query"] else "red"),
                 style(
+                    r["src_owner_query"],
+                    "green" if r["src_owner_query"] else "red",
+                ),
+                style(
                     r["src_to_dst_dblink"],
                     "green" if r["src_to_dst_dblink"] else "red",
                 ),
                 style(r["dst_tcp"], "green" if r["dst_tcp"] else "red"),
                 style(r["dst_query"], "green" if r["dst_query"] else "red"),
+                style(
+                    r["dst_owner_query"],
+                    "green" if r["dst_owner_query"] else "red",
+                ),
                 style(
                     r["dst_to_src_dblink"],
                     "green" if r["dst_to_src_dblink"] else "red",
@@ -130,9 +150,11 @@ async def _print_connectivity_results(results: list[dict]):
             [
                 r["src_tcp"],
                 r["src_query"],
+                r["src_owner_query"],
                 r["src_to_dst_dblink"],
                 r["dst_tcp"],
                 r["dst_query"],
+                r["dst_owner_query"],
                 r["dst_to_src_dblink"],
             ]
         ):
@@ -161,16 +183,74 @@ async def _check_tcp(host: str, port: str, logger: Logger) -> bool:
     return False
 
 
+async def _check_owner_query(
+    owner_uri: str,
+    label: str,
+    logger: Logger,
+    timeout: float = _OWNER_PROBE_TIMEOUT_SECONDS,
+) -> bool:
+    """Validate owner credentials by opening one asyncpg connection
+    against ``owner_uri`` and running ``SELECT 1`` -- with a short
+    timeout so a silent server-side reset on a bad/stale owner password
+    fails fast instead of consuming asyncpg's 60s default.
+
+    Returns True on success. Logs the underlying error and returns False
+    on any failure -- the caller surfaces this in the JSON output as
+    ``{src,dst}_owner_query: false`` (and on the per-DB ``failed_checks``
+    list), giving operators a concrete pointer to a credential issue.
+    """
+    logger.info("Checking %s SELECT 1 (timeout=%gs)...", label, timeout)
+    conn = None
+    try:
+        conn = await asyncpg.connect(owner_uri, timeout=timeout)
+        await wait_for(conn.fetchval("SELECT 1"), timeout=timeout)
+        logger.debug("%s SELECT 1 succeeded.", label)
+        return True
+    except TimeoutError:
+        # Distinct from the generic Exception branch because a timeout
+        # is the smoking gun for a wrong owner password against RDS:
+        # the server stays silent and asyncpg keeps retrying until the
+        # configured connect_timeout elapses.
+        logger.error(
+            "%s SELECT 1 timed out after %gs (owner password likely wrong/stale)",
+            label,
+            timeout,
+        )
+        return False
+    except Exception as e:
+        logger.error("%s SELECT 1 failed: %s: %s", label, type(e).__name__, e)
+        return False
+    finally:
+        if conn is not None:
+            try:
+                await conn.close(timeout=2)
+            except Exception as close_exc:
+                # The probe's whole job is to answer "can owner
+                # authenticate?"; a stuck close is unrelated noise we
+                # don't want to mask the verdict with. Log at debug so
+                # we still leave a breadcrumb for the rare case where
+                # the server is wedged badly enough to also block close.
+                logger.debug(
+                    "%s connection close failed (ignored): %s",
+                    label,
+                    close_exc,
+                )
+
+
 @run_with_configs(results_callback=_print_connectivity_results)
 async def check_connectivity(config_future: Awaitable[DbupgradeConfig]) -> None:
     """
     Returns exit code 0 if pgbelt can connect to all databases in a datacenter
     (if db is not specified), or to both src and dst of a database.
 
-    Runs three checks per side:
+    Runs four checks per side:
     1. TCP connectivity to the database port (from pgbelt).
-    2. SELECT 1 via a connection pool (validates credentials from pgbelt).
-    3. dblink from src->dst and dst->src (validates that the database servers
+    2. SELECT 1 via a root-credentials connection pool (validates root creds
+    from pgbelt).
+    3. SELECT 1 via the owner-credentials URI with a 10s timeout (validates
+    owner creds; without this, a wrong/stale owner password would be caught
+    much later inside ``belt precheck`` as a 60s asyncpg pool-creation hang).
+    4. dblink from src->dst and dst->src (validates that the database servers
     themselves can reach each other -- the same network path pglogical uses).
 
     The dblink extension is created if not present and left in place. It is
@@ -190,6 +270,8 @@ async def check_connectivity(config_future: Awaitable[DbupgradeConfig]) -> None:
 
     src_query = False
     dst_query = False
+    src_owner_query = False
+    dst_owner_query = False
     src_to_dst_dblink = False
     dst_to_src_dblink = False
 
@@ -216,6 +298,20 @@ async def check_connectivity(config_future: Awaitable[DbupgradeConfig]) -> None:
             except Exception as e:
                 dst_logger.error(f"SELECT 1 failed: {e}")
 
+            # Owner-credential probes -- gated on the matching root
+            # SELECT 1 because owner sits behind the same network
+            # path; if root can't query, owner won't either, and we'd
+            # rather surface the underlying network/RDS problem on the
+            # ``*_query`` cell than double-flag it.
+            if src_query:
+                src_owner_query = await _check_owner_query(
+                    conf.src.owner_uri, "src owner", src_logger
+                )
+            if dst_query:
+                dst_owner_query = await _check_owner_query(
+                    conf.dst.owner_uri, "dst owner", dst_logger
+                )
+
             # dblink cross-host checks
             if src_query and dst_query:
                 await gather(
@@ -239,6 +335,10 @@ async def check_connectivity(config_future: Awaitable[DbupgradeConfig]) -> None:
                 src_logger.debug("SELECT 1 succeeded.")
             except Exception as e:
                 src_logger.error(f"SELECT 1 failed: {e}")
+        if src_query:
+            src_owner_query = await _check_owner_query(
+                conf.src.owner_uri, "src owner", src_logger
+            )
     elif dst_tcp:
         async with create_pool(conf.dst.root_uri, min_size=1) as dst_pool:
             try:
@@ -247,14 +347,20 @@ async def check_connectivity(config_future: Awaitable[DbupgradeConfig]) -> None:
                 dst_logger.debug("SELECT 1 succeeded.")
             except Exception as e:
                 dst_logger.error(f"SELECT 1 failed: {e}")
+        if dst_query:
+            dst_owner_query = await _check_owner_query(
+                conf.dst.owner_uri, "dst owner", dst_logger
+            )
 
     return {
         "db": conf.db,
         "src_tcp": src_tcp,
         "src_query": src_query,
+        "src_owner_query": src_owner_query,
         "src_to_dst_dblink": src_to_dst_dblink,
         "dst_tcp": dst_tcp,
         "dst_query": dst_query,
+        "dst_owner_query": dst_owner_query,
         "dst_to_src_dblink": dst_to_src_dblink,
     }
 

--- a/pgbelt/models/connectivity.py
+++ b/pgbelt/models/connectivity.py
@@ -8,14 +8,27 @@ from pgbelt.models.base import CommandResult
 
 
 class ConnectivityCheckRow(BaseModel):
-    """Connectivity results for a single database pair."""
+    """Connectivity results for a single database pair.
+
+    The ``*_owner_query`` fields validate that the *owner* credentials
+    (not just root) can authenticate and ``SELECT 1``. They were added
+    because ``belt precheck`` is the first command that opens an
+    owner-pool against the source, and on a wrong / stale owner password
+    against a managed RDS the asyncpg ``create_pool`` hangs for the full
+    ``connect_timeout`` (60s) before surfacing a bare ``TimeoutError``
+    with no message. Probing owner here at the connectivity stage keeps
+    that failure visible on the per-DB grid (and 6x faster) instead of
+    poisoning the next stage.
+    """
 
     db: str
     src_tcp: bool
     src_query: bool
+    src_owner_query: bool
     src_to_dst_dblink: bool
     dst_tcp: bool
     dst_query: bool
+    dst_owner_query: bool
     dst_to_src_dblink: bool
 
     @computed_field
@@ -25,9 +38,11 @@ class ConnectivityCheckRow(BaseModel):
             [
                 self.src_tcp,
                 self.src_query,
+                self.src_owner_query,
                 self.src_to_dst_dblink,
                 self.dst_tcp,
                 self.dst_query,
+                self.dst_owner_query,
                 self.dst_to_src_dblink,
             ]
         )
@@ -38,9 +53,11 @@ class ConnectivityCheckRow(BaseModel):
         checks = {
             "src_tcp": self.src_tcp,
             "src_query": self.src_query,
+            "src_owner_query": self.src_owner_query,
             "src_to_dst_dblink": self.src_to_dst_dblink,
             "dst_tcp": self.dst_tcp,
             "dst_query": self.dst_query,
+            "dst_owner_query": self.dst_owner_query,
             "dst_to_src_dblink": self.dst_to_src_dblink,
         }
         return [name for name, passed in checks.items() if not passed]

--- a/tests/pgbelt/cmd/test_convenience.py
+++ b/tests/pgbelt/cmd/test_convenience.py
@@ -1,7 +1,10 @@
-from unittest import TestCase
+import logging
+from unittest.mock import AsyncMock
 from unittest.mock import Mock
 from unittest.mock import patch
 
+import asyncpg
+import pytest
 from pgbelt.cmd import convenience
 
 
@@ -12,3 +15,196 @@ def test_src_dsn_owner(config):
         convenience.echo = Mock()
         convenience.src_dsn("test-db", "test-dc")
         convenience.echo.assert_called_with(config.src.owner_dsn)
+
+
+# ---------------------------------------------------------------------------
+# Owner-credential probe -- the regression target for
+# https://jira.autodesk.com/browse/STOPS-7717
+# ---------------------------------------------------------------------------
+#
+# ``belt precheck`` opens an owner-pool against the source via
+# ``asyncpg.create_pool(conf.src.owner_uri, min_size=1)``. With a wrong
+# or stale owner password against a managed RDS (which silently closes
+# the connection rather than returning a structured auth error), this
+# hangs for the full ``connect_timeout=60s`` and surfaces a bare
+# ``TimeoutError`` with no message. ``check-connectivity`` now probes
+# owner-creds upfront with a 10s timeout, so the failure becomes a
+# clean ``src_owner_query=false`` cell on the per-DB grid.
+
+
+@pytest.fixture
+def logger():
+    return logging.getLogger("test.owner-probe")
+
+
+class TestCheckOwnerQuery:
+    @pytest.mark.asyncio
+    async def test_returns_true_on_successful_select(self, logger):
+        """Happy path: connect + SELECT 1 + close == probe passes."""
+        conn = AsyncMock()
+        conn.fetchval.return_value = 1
+        with patch(
+            "pgbelt.cmd.convenience.asyncpg.connect",
+            new=AsyncMock(return_value=conn),
+        ) as mock_connect:
+            ok = await convenience._check_owner_query(
+                "postgresql://owner:p@h:5432/db", "src owner", logger, timeout=5.0
+            )
+        assert ok is True
+        mock_connect.assert_awaited_once_with(
+            "postgresql://owner:p@h:5432/db", timeout=5.0
+        )
+        conn.fetchval.assert_awaited_once_with("SELECT 1")
+        conn.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_connect_timeout(self, logger):
+        """asyncpg's own ``timeout`` triggers ``TimeoutError`` -- caught
+        explicitly so we can log the actionable hint and avoid the 60s
+        default that motivated this whole probe."""
+        with patch(
+            "pgbelt.cmd.convenience.asyncpg.connect",
+            new=AsyncMock(side_effect=TimeoutError()),
+        ):
+            ok = await convenience._check_owner_query(
+                "postgresql://owner:bad@h:5432/db",
+                "src owner",
+                logger,
+                timeout=0.5,
+            )
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_invalid_password(self, logger):
+        """A structured auth error is the cleaner of the two failure
+        modes (vs the silent timeout path); make sure it's also caught
+        rather than bubbling up."""
+        with patch(
+            "pgbelt.cmd.convenience.asyncpg.connect",
+            new=AsyncMock(
+                side_effect=asyncpg.exceptions.InvalidPasswordError(
+                    "password authentication failed for user 'owner'"
+                )
+            ),
+        ):
+            ok = await convenience._check_owner_query(
+                "postgresql://owner:wrong@h:5432/db",
+                "src owner",
+                logger,
+            )
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_select_fails_but_still_closes(self, logger):
+        """Auth succeeded but the server killed the session before
+        SELECT 1 returned. Still must return False AND release the
+        connection so we don't leak it back into the pool tests."""
+        conn = AsyncMock()
+        conn.fetchval.side_effect = RuntimeError("server closed the connection")
+        with patch(
+            "pgbelt.cmd.convenience.asyncpg.connect",
+            new=AsyncMock(return_value=conn),
+        ):
+            ok = await convenience._check_owner_query(
+                "postgresql://owner:p@h:5432/db", "src owner", logger
+            )
+        assert ok is False
+        conn.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_close_failure_is_swallowed(self, logger):
+        """``conn.close()`` raising must not mask a successful probe --
+        the probe's whole job is to answer 'can owner authenticate?'
+        and a stuck close is unrelated noise."""
+        conn = AsyncMock()
+        conn.fetchval.return_value = 1
+        conn.close.side_effect = RuntimeError("close timed out")
+        with patch(
+            "pgbelt.cmd.convenience.asyncpg.connect",
+            new=AsyncMock(return_value=conn),
+        ):
+            ok = await convenience._check_owner_query(
+                "postgresql://owner:p@h:5432/db", "src owner", logger
+            )
+        assert ok is True
+
+
+class TestCheckConnectivityOwnerProbe:
+    """End-to-end check: ``check_connectivity`` must run the owner probe
+    once root SELECT 1 succeeds, and surface its boolean verdict in the
+    returned dict so ``ConnectivityCheckRow`` can serialize the new
+    ``{src,dst}_owner_query`` fields."""
+
+    @pytest.mark.asyncio
+    async def test_owner_probe_invoked_when_root_query_passes(self, config):
+        """Both root SELECT 1s pass -> both owner probes get called
+        with the matching side's ``owner_uri``."""
+
+        async def _config_future():
+            return config
+
+        root_pool = AsyncMock()
+        root_pool.fetchval.return_value = 1
+        root_pool.close = AsyncMock()
+
+        with (
+            patch(
+                "pgbelt.cmd.convenience._check_tcp", new=AsyncMock(return_value=True)
+            ),
+            patch(
+                "pgbelt.cmd.convenience.create_pool",
+                new=AsyncMock(return_value=root_pool),
+            ),
+            patch("pgbelt.cmd.convenience.ensure_dblink", new=AsyncMock()),
+            patch(
+                "pgbelt.cmd.convenience.check_connectivity_via_dblink",
+                new=AsyncMock(return_value=True),
+            ),
+            patch(
+                "pgbelt.cmd.convenience._check_owner_query",
+                new=AsyncMock(return_value=True),
+            ) as mock_owner,
+        ):
+            result = await convenience.check_connectivity.__wrapped__(_config_future())
+
+        assert result["src_owner_query"] is True
+        assert result["dst_owner_query"] is True
+        assert mock_owner.await_count == 2
+        called_uris = {c.args[0] for c in mock_owner.await_args_list}
+        assert config.src.owner_uri in called_uris
+        assert config.dst.owner_uri in called_uris
+
+    @pytest.mark.asyncio
+    async def test_owner_probe_skipped_when_root_query_fails(self, config):
+        """If root SELECT 1 fails (network / RDS-level issue), the
+        owner probe is skipped on that side -- the underlying problem
+        is already surfaced via ``*_query`` and we don't want to
+        double-flag it as a credential issue."""
+
+        async def _config_future():
+            return config
+
+        root_pool = AsyncMock()
+        root_pool.fetchval.side_effect = RuntimeError("connection refused")
+        root_pool.close = AsyncMock()
+
+        with (
+            patch(
+                "pgbelt.cmd.convenience._check_tcp", new=AsyncMock(return_value=True)
+            ),
+            patch(
+                "pgbelt.cmd.convenience.create_pool",
+                new=AsyncMock(return_value=root_pool),
+            ),
+            patch(
+                "pgbelt.cmd.convenience._check_owner_query",
+                new=AsyncMock(return_value=True),
+            ) as mock_owner,
+        ):
+            result = await convenience.check_connectivity.__wrapped__(_config_future())
+
+        assert result["src_query"] is False
+        assert result["dst_query"] is False
+        assert result["src_owner_query"] is False
+        assert result["dst_owner_query"] is False
+        mock_owner.assert_not_awaited()

--- a/tests/pgbelt/cmd/test_json_flag.py
+++ b/tests/pgbelt/cmd/test_json_flag.py
@@ -124,9 +124,11 @@ class TestBuildJsonOutputRichModels:
                     "db": "db1",
                     "src_tcp": True,
                     "src_query": True,
+                    "src_owner_query": True,
                     "src_to_dst_dblink": True,
                     "dst_tcp": True,
                     "dst_query": True,
+                    "dst_owner_query": True,
                     "dst_to_src_dblink": True,
                 }
             ],
@@ -150,9 +152,12 @@ class TestBuildJsonOutputRichModels:
                     "db": "db1",
                     "src_tcp": True,
                     "src_query": True,
+                    "src_owner_query": True,
                     "src_to_dst_dblink": False,
                     "dst_tcp": True,
                     "dst_query": False,
+                    # owner gated on root SELECT 1 -> False when dst_query=False
+                    "dst_owner_query": False,
                     "dst_to_src_dblink": False,
                 }
             ],
@@ -165,8 +170,38 @@ class TestBuildJsonOutputRichModels:
         assert set(result.results[0].failed_checks) == {
             "src_to_dst_dblink",
             "dst_query",
+            "dst_owner_query",
             "dst_to_src_dblink",
         }
+
+    def test_check_connectivity_owner_only_failure(self):
+        """Wrong/stale owner password -- the rest of the grid is green
+        but ``src_owner_query`` is False so the operator can pinpoint
+        the credential issue instead of waiting 60s for a bare
+        TimeoutError out of ``belt precheck``."""
+        output = _build_json_output(
+            command_name="check-connectivity",
+            dc="dc1",
+            db="db1",
+            results=[
+                {
+                    "db": "db1",
+                    "src_tcp": True,
+                    "src_query": True,
+                    "src_owner_query": False,
+                    "src_to_dst_dblink": True,
+                    "dst_tcp": True,
+                    "dst_query": True,
+                    "dst_owner_query": True,
+                    "dst_to_src_dblink": True,
+                }
+            ],
+            success=False,
+            duration_ms=10500,
+        )
+        result = ConnectivityCheckResult.model_validate_json(output)
+        assert result.overall_ok is False
+        assert result.results[0].failed_checks == ["src_owner_query"]
 
     def test_check_connectivity_multi_db(self):
         output = _build_json_output(
@@ -178,18 +213,22 @@ class TestBuildJsonOutputRichModels:
                     "db": "db1",
                     "src_tcp": True,
                     "src_query": True,
+                    "src_owner_query": True,
                     "src_to_dst_dblink": True,
                     "dst_tcp": True,
                     "dst_query": True,
+                    "dst_owner_query": True,
                     "dst_to_src_dblink": True,
                 },
                 {
                     "db": "db2",
                     "src_tcp": True,
                     "src_query": True,
+                    "src_owner_query": True,
                     "src_to_dst_dblink": True,
                     "dst_tcp": True,
                     "dst_query": True,
+                    "dst_owner_query": True,
                     "dst_to_src_dblink": True,
                 },
             ],

--- a/tests/pgbelt/models/test_round_trips.py
+++ b/tests/pgbelt/models/test_round_trips.py
@@ -255,9 +255,11 @@ class TestConnectivityCheckResult:
             db=db,
             src_tcp=all_pass,
             src_query=all_pass,
+            src_owner_query=all_pass,
             src_to_dst_dblink=all_pass,
             dst_tcp=all_pass,
             dst_query=all_pass,
+            dst_owner_query=all_pass,
             dst_to_src_dblink=all_pass,
         )
 
@@ -277,9 +279,11 @@ class TestConnectivityCheckResult:
             db="db2",
             src_tcp=True,
             src_query=True,
+            src_owner_query=True,
             src_to_dst_dblink=False,
             dst_tcp=True,
             dst_query=False,
+            dst_owner_query=False,
             dst_to_src_dblink=False,
         )
         result = ConnectivityCheckResult(
@@ -289,9 +293,15 @@ class TestConnectivityCheckResult:
         )
         restored = _round_trip(ConnectivityCheckResult, result)
         assert restored.overall_ok is False
+        # ``dst_owner_query`` is False here because owner is gated on
+        # the matching root SELECT 1 -- if root can't query, the owner
+        # probe is presumed False (the underlying network/RDS failure
+        # surfaces on ``dst_query`` and we don't double-flag it as a
+        # credential issue).
         assert set(restored.results[0].failed_checks) == {
             "src_to_dst_dblink",
             "dst_query",
+            "dst_owner_query",
             "dst_to_src_dblink",
         }
 


### PR DESCRIPTION
## Summary

`belt precheck` is the first command that opens an `asyncpg` pool against `conf.src.owner_uri`. With wrong / stale owner creds against a managed RDS the server silently closes the connection rather than returning a structured auth error, and asyncpg's default `connect_timeout=60s` makes `create_pool(min_size=1)` retry until it elapses — surfacing as a bare `TimeoutError` with no message ([STOPS-7717](https://jira.autodesk.com/browse/STOPS-7717)).

This adds a dedicated owner-credential probe to `check-connectivity` so the failure shows up at the connectivity stage with a meaningful error, instead of poisoning the next stage.

## Changes

- **`pgbelt/cmd/convenience.py`**: new `_check_owner_query` helper opens one `asyncpg.connect(owner_uri, timeout=10s)` and runs `SELECT 1`. Distinguishes `TimeoutError` (logged as "owner password likely wrong/stale") from generic `Exception`. Always closes the connection with a 2s timeout in `finally`; close-failures are logged at debug, never re-raised.
- **`pgbelt/cmd/convenience.py`**: `check_connectivity` now invokes the probe for each side, gated on the matching root `SELECT 1`. If root can't query, the underlying network/RDS issue is already on the `*_query` cell and we don't double-flag it.
- **`pgbelt/cmd/convenience.py`**: human-readable connectivity table renders two new columns (`SrcOwnerQ`, `DstOwnerQ`); JSON output gains `src_owner_query` / `dst_owner_query`.
- **`pgbelt/models/connectivity.py`**: `ConnectivityCheckRow` gets `src_owner_query: bool` / `dst_owner_query: bool` as required fields. The existing computed `all_ok` and `failed_checks` automatically include them, so any consumer that reads either picks up the new check.

## Test plan

- [x] `pytest tests/pgbelt/cmd/test_convenience.py` -- 8 new cases covering successful probe, connect timeout, `InvalidPasswordError`, post-connect SELECT failure, graceful close-failure, and the gating behaviour in `check_connectivity` (probes when root passes, skipped when it fails).
- [x] `pytest tests/pgbelt/cmd/test_json_flag.py` -- 4 cases updated for the new fields including a new owner-only-failure regression.
- [x] `pytest tests/pgbelt/models/test_round_trips.py` -- partial-failure case extended to confirm `failed_checks` lists the owner cells.
- [x] `pre-commit run -a` (black + flake8 + ruff): clean.
- [ ] Live repro on `dev-use1-pg-1/project-events`: gated on the pgbaas image being rebuilt off this branch.

## Companion PR

`pgbaas` ships the matching wrapper test + a temporary Dockerfile pin so the rebuilt image carries this fix before pgbelt 0.20.2 ships: https://git.autodesk.com/plangrid/pgbaas/pull/129