### PR TITLE
feat(create-indexes): add --concurrently flag

### DIFF
--- a/pgbelt/cmd/schema.py
+++ b/pgbelt/cmd/schema.py
@@ -92,6 +92,20 @@ async def remove_indexes(config_future: Awaitable[DbupgradeConfig]) -> None:
 @run_with_configs(skip_src=True)
 async def create_indexes(
     config_future: Awaitable[DbupgradeConfig],
+    concurrently: bool = Option(
+        False,
+        "--concurrently",
+        help=(
+            "Build each index with CREATE INDEX CONCURRENTLY so the build "
+            "does not take a ShareLock on the table. Use this when the "
+            "destination is already serving live traffic (e.g. a post-cutover "
+            "re-run) or when concurrent writers/replication must not be "
+            "blocked. Wall-clock is roughly 1.5-2x slower than the default "
+            "non-CONCURRENT build under active write load; if a CONCURRENTLY "
+            "build fails midway the index is left invalid and must be dropped "
+            "before retry."
+        ),
+    ),
 ) -> dict[str, Any] | None:
     """
     Creates indexes from the file schemas/dc/db/indexes.sql into the destination
@@ -105,7 +119,7 @@ async def create_indexes(
     conf = await config_future
     logger = get_logger(conf.db, conf.dc, "schema.dst")
     index_details = await create_target_indexes_with_details(
-        conf, logger, during_sync=False
+        conf, logger, during_sync=False, concurrently=concurrently
     )
 
     async with create_pool(

--- a/pgbelt/util/dump.py
+++ b/pgbelt/util/dump.py
@@ -5,7 +5,7 @@ from os.path import join
 from pgbelt.config.models import DbupgradeConfig
 from pgbelt.util.asyncfuncs import makedirs
 from pgbelt.util.postgres import table_empty
-from re import finditer, IGNORECASE, search
+from re import finditer, IGNORECASE, search, sub as re_sub
 
 from aiofiles import open as aopen
 from asyncpg import create_pool
@@ -665,12 +665,44 @@ async def create_target_indexes(
                 raise Exception(e)
 
 
+def _inject_concurrently(statement: str) -> str:
+    """Rewrite a single ``CREATE [UNIQUE] INDEX ...`` statement so the build
+    runs with ``CONCURRENTLY``.
+
+    ``CONCURRENTLY`` slots in after the ``INDEX`` keyword and before either an
+    optional ``IF NOT EXISTS`` clause or the index name. Returns the input
+    unchanged if it doesn't contain a CREATE INDEX, or if CONCURRENTLY is
+    already present (so calling this twice is a no-op).
+    """
+    return re_sub(
+        r"(\bCREATE\s+(?:UNIQUE\s+)?INDEX)\b(?!\s+CONCURRENTLY)",
+        r"\1 CONCURRENTLY",
+        statement,
+        flags=IGNORECASE,
+    )
+
+
 async def create_target_indexes_with_details(
-    config: DbupgradeConfig, logger: Logger, during_sync=False
+    config: DbupgradeConfig,
+    logger: Logger,
+    during_sync: bool = False,
+    concurrently: bool = False,
 ) -> list[dict]:
     """
     Like create_target_indexes but returns per-index detail dicts suitable for
     building a CreateIndexesResult model.
+
+    When ``concurrently`` is True, each ``CREATE INDEX`` is rewritten to
+    ``CREATE INDEX CONCURRENTLY`` so the build doesn't take a ``ShareLock``
+    on the table. This is the safe choice when the destination is already
+    serving live traffic (e.g. post-cutover re-runs), and the only correct
+    choice when concurrent writers must not be blocked. The tradeoff: a
+    CONCURRENTLY build runs two heap passes plus a ``WaitForOlderSnapshots``
+    barrier, so wall-clock is roughly 1.5-2x the non-CONCURRENT build under
+    active write load. Note that if a CONCURRENTLY build fails midway the
+    index is left ``indisvalid = false`` and must be dropped before retry --
+    this function still surfaces a ``status: failed`` entry but does not
+    auto-drop the invalid index.
     """
     import time
 
@@ -685,7 +717,10 @@ async def create_target_indexes_with_details(
     async with aopen(schema_file(config.db, config.dc, ONLY_INDEXES), "r") as f:
         create_index_statements = await f.read()
 
-    logger.info("Creating indexes on the target...")
+    logger.info(
+        "Creating indexes on the target%s...",
+        " (CONCURRENTLY)" if concurrently else "",
+    )
     details: list[dict] = []
 
     for c in create_index_statements.split(";"):
@@ -696,6 +731,9 @@ async def create_target_indexes_with_details(
         if not regex_matches:
             continue
         index = regex_matches.groupdict()["index"].replace('"', "")
+
+        if concurrently:
+            c = _inject_concurrently(c)
 
         host_dsn = config.dst.owner_dsn + " options='-c statement_timeout=0'"
         command = ["psql", host_dsn, "-c", f"{c};"]

--- a/tests/pgbelt/util/test_inject_concurrently.py
+++ b/tests/pgbelt/util/test_inject_concurrently.py
@@ -1,0 +1,65 @@
+from pgbelt.util.dump import _inject_concurrently
+
+
+def test_basic_create_index():
+    out = _inject_concurrently("CREATE INDEX idx_foo ON public.t (a)")
+    assert out == "CREATE INDEX CONCURRENTLY idx_foo ON public.t (a)"
+
+
+def test_create_unique_index():
+    out = _inject_concurrently("CREATE UNIQUE INDEX idx_foo ON public.t (a)")
+    assert out == "CREATE UNIQUE INDEX CONCURRENTLY idx_foo ON public.t (a)"
+
+
+def test_case_insensitive():
+    out = _inject_concurrently("create index idx_foo on public.t (a)")
+    assert out == "create index CONCURRENTLY idx_foo on public.t (a)"
+
+
+def test_idempotent():
+    once = _inject_concurrently("CREATE INDEX idx_foo ON public.t (a)")
+    twice = _inject_concurrently(once)
+    assert once == twice
+
+
+def test_idempotent_with_existing_concurrently():
+    src = "CREATE INDEX CONCURRENTLY idx_foo ON public.t (a)"
+    assert _inject_concurrently(src) == src
+
+
+def test_extra_whitespace_preserved():
+    out = _inject_concurrently("CREATE  INDEX  idx_foo ON public.t (a)")
+    assert out == "CREATE  INDEX CONCURRENTLY  idx_foo ON public.t (a)"
+
+
+def test_hash_index_with_expression():
+    # Mirrors the real-world projectevents14 case (STOPS-7797): a hash
+    # index over a jsonb extraction expression.
+    src = (
+        "CREATE INDEX project_events_idx_field_report_type_uid ON "
+        "public.project_events USING hash "
+        "(((event_data ->> 'field_report_type_uid'::text)))"
+    )
+    out = _inject_concurrently(src)
+    assert out.startswith("CREATE INDEX CONCURRENTLY ")
+    # Ensure we didn't double-inject inside the expression body
+    assert out.count("CONCURRENTLY") == 1
+
+
+def test_leading_comment_and_set_block():
+    # pg_dump output typically includes SET statements and comments before
+    # the CREATE INDEX. The function operates on individual statements
+    # (split on ;) but should still inject correctly if a single statement
+    # has leading whitespace / SET.
+    src = "\n  CREATE INDEX idx_foo ON public.t (a)"
+    out = _inject_concurrently(src)
+    assert out == "\n  CREATE INDEX CONCURRENTLY idx_foo ON public.t (a)"
+
+
+def test_non_create_index_unchanged():
+    src = "ALTER TABLE foo ADD CONSTRAINT bar CHECK (a > 0) NOT VALID"
+    assert _inject_concurrently(src) == src
+
+
+def test_empty_string_unchanged():
+    assert _inject_concurrently("") == ""


### PR DESCRIPTION
## Summary

Adds an opt-in `--concurrently` flag to `belt create-indexes` that rewrites each `CREATE [UNIQUE] INDEX` statement read from `schemas/<dc>/<db>/indexes.sql` to inject `CONCURRENTLY` before the build runs.

## Motivation

Default behavior is unchanged: a plain `CREATE INDEX` takes `ShareLock` on the table for the duration of the build, which is fine pre-cutover for small/medium tables but **blocks all writers** (including pglogical apply during replication) for the entire build. On large tables this regularly times out the orchestrating workflow with the build still in progress on the database.

## Behavior

- `belt create-indexes <dc> <pair>` (default) → unchanged. Single heap pass, ShareLock for the duration.
- `belt create-indexes <dc> <pair> --concurrently` → each emitted SQL is rewritten as `CREATE [UNIQUE] INDEX CONCURRENTLY ...`. ShareUpdateExclusiveLock only, no writer blockage.

## Tradeoffs (called out in `--help` and docstring)

CONCURRENTLY runs two heap passes plus a `WaitForOlderSnapshots` barrier between phases, so wall-clock is roughly 1.5–2x the non-CONCURRENT build under active write load. A failed mid-build leaves the index marked `indisvalid = false` and requires a manual `DROP INDEX` before retry. For the common case of small dev tables the default non-CONCURRENT build is faster and the brief ShareLock is harmless, which is why this stays opt-in.

## Scope

- Threaded through `create_target_indexes_with_details` only (which the `create-indexes` command calls).
- The sync-path `create_target_indexes` (called from `belt sync` during initial bulk load) is intentionally **not** touched in this PR — that path runs before any traffic is on the destination, so the ShareLock has nothing to conflict with.

## Test plan

- [x] New unit tests for `_inject_concurrently` covering basic, unique, case-insensitive, idempotence, whitespace preservation, the real-world hash-on-jsonb-expression shape, and non-CREATE-INDEX statements. All 10 pass.
- [x] `black --check` clean
- [x] Pre-commit (black, flake8, ruff, prettier, end-of-file-fixer) clean
- [ ] Smoke-test against a real pair: build with and without the flag, confirm `pg_stat_progress_create_index` shows the CONCURRENTLY behavior (two-phase, no ShareLock on the table). To be done downstream once a pgbelt release lands and pgbaas pins to it.


🤖 Generated with [Claude Code](https://claude.com/claude-code)