### PR TITLE
fix(sync-sequences): PK path uses GREATEST(max(pk_col), src.last_value)

### DIFF
--- a/pgbelt/cmd/sync.py
+++ b/pgbelt/cmd/sync.py
@@ -57,15 +57,26 @@ async def _sync_sequences(
     src_logger.info(f"Total sequences to sync: {seq_vals.keys()}")
 
     non_pk_vals = {k: v for k, v in seq_vals.items() if k not in pk_seqs}
+    # Source last_values for the PK subset. Passed into
+    # set_pk_sequences_from_data so each PK sequence is bumped to
+    # GREATEST(max(dst.pk_col), src.last_value) -- matching what
+    # diff-sequences subsequently checks. Without this, rolled-back
+    # inserts / deletes / nextval cache on the source leave
+    # max(pk_col) strictly below src.last_value, so a healthy
+    # cutover with caught-up replication still flunks diff-sequences.
+    src_pk_vals = {k: v for k, v in seq_vals.items() if k in pk_seqs}
     src_logger.info(f"PK sequences: {list(pk_seqs.keys())}")
     src_logger.info(f"Non-PK sequences: {list(non_pk_vals.keys())}")
 
     if pk_seqs:
-        await set_pk_sequences_from_data(dst_pool, pk_seqs, schema, dst_logger)
+        await set_pk_sequences_from_data(
+            dst_pool, pk_seqs, schema, dst_logger, src_pk_vals=src_pk_vals
+        )
         for name in pk_seqs:
             pk_details.append(
                 {
                     "name": name,
+                    "source_value": src_pk_vals.get(name),
                     "synced": True,
                     "method": "pk_max",
                 }

--- a/pgbelt/util/postgres.py
+++ b/pgbelt/util/postgres.py
@@ -150,50 +150,89 @@ async def detect_pk_sequences(
     return pk_seqs
 
 
+def _build_pk_setval_sql(
+    pk_seqs: dict[str, tuple[str, str]],
+    schema: str,
+    src_pk_vals: dict[str, int] | None = None,
+) -> str:
+    """Render the multi-statement ``setval`` block for PK sequences.
+
+    Split out from ``set_pk_sequences_from_data`` so the SQL shape can be
+    unit-tested without a live asyncpg pool. See the function it serves
+    for the rationale behind the GREATEST(max(pk_col), src.last_value)
+    expression.
+    """
+    src_pk_vals = src_pk_vals or {}
+    parts: list[str] = []
+    for seq_name, (table_name, col_name) in pk_seqs.items():
+        # asyncpg's prepared-statement parameter binding doesn't span
+        # multiple statements concatenated into a single ``execute``
+        # call, so we render ``src_last`` inline. It's an integer we
+        # read from pg_sequence, never operator input, which keeps
+        # this injection-safe.
+        src_last = int(src_pk_vals.get(seq_name) or 0)
+        parts.append(
+            f"SELECT setval('{schema}.\"{seq_name}\"', "
+            f'GREATEST(coalesce(max("{col_name}"), 1), {src_last}), '
+            f'(max("{col_name}") IS NOT null) OR ({src_last} > 1)) '
+            f'FROM {schema}."{table_name}";'
+        )
+    return "\n".join(parts)
+
+
 async def set_pk_sequences_from_data(
     pool: Pool,
     pk_seqs: dict[str, tuple[str, str]],
     schema: str,
     logger: Logger,
+    src_pk_vals: dict[str, int] | None = None,
 ) -> None:
     """
     For sequences that back primary key columns, set each sequence value to the
-    maximum value currently present in the corresponding table column.
+    greater of ``max(<pk_col>)`` on the destination table and the source
+    sequence's ``last_value``.
 
-    Uses the standard PostgreSQL idiom::
+    Uses the standard PostgreSQL ``setval`` idiom, with ``GREATEST`` to take
+    whichever of the two baselines is larger::
 
         SELECT setval('<schema>."<seq>"',
-                      coalesce(max("<col>"), 1),
-                      max("<col>") IS NOT null)
+                      GREATEST(coalesce(max("<col>"), 1), <src_last>),
+                      (max("<col>") IS NOT null) OR (<src_last> > 1))
         FROM <schema>."<table>";
 
-    This ensures the sequence is always at or above the highest existing primary
-    key value, which is the safest baseline regardless of whether we are reading
-    from source or destination.
+    Why both?
+
+    * ``max(<pk_col>)`` on the destination is the safest *minimum* — the next
+      ``nextval()`` must not collide with an existing row.
+    * The source sequence's ``last_value`` is what the source database would
+      have produced on its next ``INSERT``, and is what ``belt diff-sequences``
+      compares against post-sync. Rolled-back inserts, ``ON CONFLICT DO
+      NOTHING`` losers, ``DELETE`` of the highest id, and ``nextval()`` caches
+      all leave ``seq.last_value`` ahead of ``max(pk_col)``, so syncing only
+      from the column max under-shoots the source on every realistic dataset.
+
+    ``src_pk_vals`` maps sequence name to the source's ``last_value`` for that
+    sequence (typically produced by ``dump_sequences`` on the source pool). It
+    is optional for backwards compatibility; when not provided or missing a
+    key, the function falls back to the DST-max-only behavior.
     """
     if not pk_seqs:
         return
+
+    src_pk_vals = src_pk_vals or {}
 
     logger.info(
         f"Setting primary key sequences from table data: {list(pk_seqs.keys())}..."
     )
 
-    sql_parts = []
-    for seq_name, (table_name, col_name) in pk_seqs.items():
-        sql_parts.append(
-            f"SELECT setval('{schema}.\"{seq_name}\"', "
-            f'coalesce(max("{col_name}"), 1), '
-            f'max("{col_name}") IS NOT null) '
-            f'FROM {schema}."{table_name}";'
-        )
-
-    sql = "\n".join(sql_parts)
+    sql = _build_pk_setval_sql(pk_seqs, schema, src_pk_vals)
     async with pool.acquire() as conn:
         async with conn.transaction():
             await conn.execute(sql)
 
     logger.debug(
-        f"Set primary key sequences to max of table data via max(column): {pk_seqs}"
+        "Set primary key sequences via GREATEST(max(pk_col), src.last_value): "
+        f"{pk_seqs} (src_pk_vals={src_pk_vals})"
     )
 
 

--- a/tests/pgbelt/util/test_set_pk_sequences_from_data.py
+++ b/tests/pgbelt/util/test_set_pk_sequences_from_data.py
@@ -1,0 +1,100 @@
+"""Unit tests for the PK ``setval`` SQL emitted by ``sync-sequences``.
+
+The async ``set_pk_sequences_from_data`` defers all SQL rendering to the
+pure helper ``_build_pk_setval_sql``; testing that helper directly avoids
+needing an event loop or asyncpg pool fixtures.
+
+Locks in the post-STOPS-7796 behavior: each PK sequence is bumped to
+``GREATEST(coalesce(max(<pk_col>), 1), <src.last_value>)`` so a healthy
+cutover with caught-up replication passes ``diff-sequences`` even when
+the source sequence is ahead of ``max(pk_col)`` (rolled-back inserts,
+``ON CONFLICT DO NOTHING`` losers, deletes of the highest id, ``nextval()``
+caches).
+"""
+
+from pgbelt.util.postgres import _build_pk_setval_sql
+
+
+def test_empty_pk_seqs_returns_empty_string():
+    assert _build_pk_setval_sql({}, "public") == ""
+
+
+def test_uses_greatest_of_pk_max_and_src_last_value():
+    sql = _build_pk_setval_sql(
+        {"users_id_seq": ("users", "id")},
+        "public",
+        src_pk_vals={"users_id_seq": 30412},
+    )
+    assert "setval('public.\"users_id_seq\"'" in sql
+    assert 'GREATEST(coalesce(max("id"), 1), 30412)' in sql
+    # is_called: true when DST has rows OR src has been called past 1.
+    assert '(max("id") IS NOT null) OR (30412 > 1)' in sql
+    assert 'FROM public."users"' in sql
+
+
+def test_falls_back_to_dst_max_when_src_pk_vals_omitted():
+    # Backwards compatibility: src_last renders as 0 so GREATEST
+    # collapses to coalesce(max(col), 1) and the is_called flag is
+    # keyed purely off max(col) IS NOT null -- same observable
+    # behavior as the pre-fix code.
+    sql = _build_pk_setval_sql(
+        {"orders_id_seq": ("orders", "order_id")},
+        "public",
+    )
+    assert 'GREATEST(coalesce(max("order_id"), 1), 0)' in sql
+    assert "(0 > 1)" in sql
+
+
+def test_missing_per_sequence_src_value_treated_as_zero():
+    sql = _build_pk_setval_sql(
+        {
+            "a_id_seq": ("a", "id"),
+            "b_id_seq": ("b", "id"),
+        },
+        "public",
+        src_pk_vals={"a_id_seq": 42},  # b_id_seq deliberately absent
+    )
+    assert 'GREATEST(coalesce(max("id"), 1), 42)' in sql
+    assert 'GREATEST(coalesce(max("id"), 1), 0)' in sql
+
+
+def test_quotes_schema_table_and_column_names():
+    # PascalCase / mixed-case identifiers must stay double-quoted on
+    # both sides of setval so PG doesn't fold them to lowercase.
+    sql = _build_pk_setval_sql(
+        {"UsersCapital_id_seq": ("UsersCapital", "Id")},
+        "PgbaasDvSrcSchema",
+        src_pk_vals={"UsersCapital_id_seq": 7},
+    )
+    assert "setval('PgbaasDvSrcSchema.\"UsersCapital_id_seq\"'" in sql
+    assert 'FROM PgbaasDvSrcSchema."UsersCapital"' in sql
+    assert 'coalesce(max("Id"), 1)' in sql
+
+
+def test_src_last_value_coerced_to_int():
+    # ``int(...)`` defensively coerces in case the upstream value is
+    # ever something other than int (e.g. a str). Guarantees the value
+    # is never SQL-quoted as a literal string.
+    sql = _build_pk_setval_sql(
+        {"x_id_seq": ("x", "id")},
+        "public",
+        src_pk_vals={"x_id_seq": "99"},  # type: ignore[dict-item]
+    )
+    assert 'GREATEST(coalesce(max("id"), 1), 99)' in sql
+    assert "'99'" not in sql
+
+
+def test_multiple_sequences_concatenated_with_newlines():
+    sql = _build_pk_setval_sql(
+        {
+            "a_id_seq": ("a", "id"),
+            "b_id_seq": ("b", "id"),
+        },
+        "public",
+        src_pk_vals={"a_id_seq": 5, "b_id_seq": 10},
+    )
+    statements = [s for s in sql.split("\n") if s.strip()]
+    assert len(statements) == 2
+    for stmt in statements:
+        assert stmt.endswith(";")
+        assert stmt.startswith("SELECT setval(")


### PR DESCRIPTION
## Problem

`belt sync-sequences` (PK path) and `belt diff-sequences` were using mismatched baselines:

- `set_pk_sequences_from_data` ran `setval(seq, coalesce(max(dst.pk_col), 1))` — deliberately ignored the source sequence's `last_value`.
- `diff-sequences` compares `src.seq.last_value` vs `dst.seq.last_value` with the gate `dst_ok = dv >= sv`.

`seq.last_value` is always ≥ `max(pk_col)` but rarely equal once a table has any real history. Rolled-back inserts, `INSERT ... ON CONFLICT DO NOTHING` losers, deletes of the highest id, and `nextval()` caches all leave the source sequence strictly ahead of `max(pk_col)`. Even with forward replication 100% caught up and the source fully quiesced, `diff-sequences` flunks because DST gets set to `max(SRC.pk_col)` and SRC is at something higher.

**Real-world hit**:
```
XXXXXXId_seq:  dst_last=30409  src_last=30412   (3 historical rollbacks)
YYYYYY_id_seq:                       dst_last=7      src_last=9       (2 failed migrations)
```

## Fix

Each PK sequence is now set to `GREATEST` of both baselines:

```sql
SELECT setval('schema."seq"',
              GREATEST(coalesce(max("col"), 1), <src_last>),
              (max("col") IS NOT null) OR (<src_last> > 1))
FROM schema."table";
```

- **`max(pk_col)` stays the safety floor** — DST sequence can never regress below DST's actual row data.
- **`src.last_value` is now plumbed in** via a new optional `src_pk_vals` kwarg. `_sync_sequences` passes the PK subset of the existing `dump_sequences(src_pool, ...)` call, so we get the source values for free with no extra round trip.
- **`is_called` flag** is `true` when DST has rows OR when the source sequence has been called past 1 — matches the semantics SRC carried.
- **Backwards compatible** — `src_pk_vals` defaults to `None`, in which case `src_last` renders as `0` and `GREATEST` collapses to `coalesce(max(col), 1)` (identical to pre-fix behavior).
- **SQL string building extracted** into a pure `_build_pk_setval_sql` helper so we can unit-test the shape without an asyncpg pool.

`diff-sequences` semantics are intentionally unchanged — `last_value` is what the next `nextval()` actually consumes, which is the operationally relevant number.

## Test plan

- [x] New `tests/pgbelt/util/test_set_pk_sequences_from_data.py` (7 sync unit tests): GREATEST expression for both common and missing src values, backwards-compat (no `src_pk_vals` arg), schema/table/column quoting, int coercion, multi-sequence concat.
- [x] Existing `tests/pgbelt/cmd/test_json_flag.py::test_sync_sequences` JSON-shape check still passes (PK rows still emit `name / synced / method`; new optional `source_value` field is populated but doesn't break the model).
- [ ] Local integration: insert + rollback 3 times on a SERIAL PK table, replicate to DST, run `belt sync-sequences` then `belt diff-sequences` — confirm `success: true` and `dst_last == src_last`.

Tracking: [STOPS-7801](https://autodesk.atlassian.net/browse/STOPS-7801) (epic [STOPS-7725](https://autodesk.atlassian.net/browse/STOPS-7725) — Ragnarok dev DB migrations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)